### PR TITLE
WildFly : REST client doesn't work, XMLHttpRequest need to be reopen before each request 

### DIFF
--- a/websocket/websocket-vs-rest/src/main/webapp/rest.js
+++ b/websocket/websocket-vs-rest/src/main/webapp/rest.js
@@ -71,9 +71,8 @@ function restEchoText() {
         payload += "x";
     }
     restStartTime = new Date().getTime();
-    
     for (var i = 0; i < times.value; i++) {
-    	xhr.open("POST", restUri, false);
+        xhr.open("POST", restUri, false);
         xhr.send(payload);
         restSendBar.value += 100 / times.value;
     }


### PR DESCRIPTION
I try to test this app with WildFly.
There is no problem for WebSocket test but REST client doesn't work (just one call works).

I'm using Google Chrome. 
It seems that XMLHttpRequest need to be reopen before each POST request.

With this code, benchmark works on my laptop.
