### PR TITLE
Moved batch-utils project one level up and renamed it to utils.

### DIFF
--- a/batch/batchlet-simple/pom.xml
+++ b/batch/batchlet-simple/pom.xml
@@ -15,8 +15,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.javaee7.batch</groupId>
-            <artifactId>batch-util</artifactId>
+            <groupId>org.javaee7</groupId>
+            <artifactId>util-samples</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/batch/batchlet-simple/src/test/java/org/javaee7/batch/batchlet/simple/MyBatchletTest.java
+++ b/batch/batchlet-simple/src/test/java/org/javaee7/batch/batchlet/simple/MyBatchletTest.java
@@ -1,6 +1,6 @@
 package org.javaee7.batch.batchlet.simple;
 
-import org.javaee7.batch.util.BatchTestHelper;
+import org.javaee7.util.BatchTestHelper;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ArchivePaths;

--- a/batch/chunk-simple/pom.xml
+++ b/batch/chunk-simple/pom.xml
@@ -20,8 +20,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.javaee7.batch</groupId>
-            <artifactId>batch-util</artifactId>
+            <groupId>org.javaee7</groupId>
+            <artifactId>util-samples</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/batch/chunk-simple/src/test/java/org/javaee7/batch/chunk/simple/ChunkSimpleTest.java
+++ b/batch/chunk-simple/src/test/java/org/javaee7/batch/chunk/simple/ChunkSimpleTest.java
@@ -1,6 +1,6 @@
 package org.javaee7.batch.chunk.simple;
 
-import org.javaee7.batch.util.BatchTestHelper;
+import org.javaee7.util.BatchTestHelper;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ArchivePaths;

--- a/batch/pom.xml
+++ b/batch/pom.xml
@@ -16,7 +16,7 @@
     <name>Java EE 7 Batch Samples</name>
 
     <modules>
-        <module>batch-util</module>
+        <!--<module>batch-util</module>-->
         <module>batchlet-simple</module>
         <module>chunk-checkpoint</module>
         <module>chunk-csv-database</module>
@@ -36,8 +36,8 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.javaee7.batch</groupId>
-                <artifactId>batch-util</artifactId>
+                <groupId>org.javaee7</groupId>
+                <artifactId>util-samples</artifactId>
                 <version>1.0-SNAPSHOT</version>
                 <scope>test</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -396,6 +396,7 @@
         <module>validation</module>
         <module>websocket</module>
         <!-- module>extra</module -->
+        <module>util</module>
     </modules>
 
     <prerequisites>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -5,13 +5,13 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.javaee7.batch</groupId>
-        <artifactId>batch-samples</artifactId>
+        <groupId>org.javaee7</groupId>
+        <artifactId>javaee7-samples</artifactId>
         <version>1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>batch-util</artifactId>
+    <artifactId>util-samples</artifactId>
     <version>1.0-SNAPSHOT</version>
 
 </project>

--- a/util/src/main/java/org/javaee7/util/BatchTestHelper.java
+++ b/util/src/main/java/org/javaee7/util/BatchTestHelper.java
@@ -1,4 +1,4 @@
-package org.javaee7.batch.util;
+package org.javaee7.util;
 
 import javax.batch.runtime.BatchStatus;
 import javax.batch.runtime.JobExecution;


### PR DESCRIPTION
Hi Arun,

I made the change to move the utils project to the top level as we agree. Hope everything is ok.

We still need to have the parent pom installed in the local repo to run the tests. I couldn't find a way around it, if we want the utils project to inherit from the top level pom. Maybe some maven specialist could help? But i suspect that's not possible. Anyway, you just need to do a mvn install -N (non recursive) on the top parent to install it.

The only way I see it working, is having utils as a separate project, outside the hierarchy of the sample, then you just install that one first and you are good to go.
