### PR TITLE
Add RESTEasy JSON-P Provider to Client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
             <artifactId>json</artifactId>
             <version>20131018</version>
             <scope>test</scope>
-        </dependency> 
+        </dependency>
     </dependencies>
     <pluginRepositories>
         <pluginRepository>
@@ -253,13 +253,19 @@
                 <dependency>
                     <groupId>org.jboss.resteasy</groupId>
                     <artifactId>resteasy-client</artifactId>
-                    <version>3.0.4.Final</version>
+                    <version>3.0.5.Final</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>
                     <groupId>org.jboss.resteasy</groupId>
                     <artifactId>resteasy-jaxb-provider</artifactId>
-                    <version>3.0.4.Final</version>
+                    <version>3.0.5.Final</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-json-p-provider</artifactId>
+                    <version>3.0.5.Final</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -323,13 +329,19 @@
                 <dependency>
                     <groupId>org.jboss.resteasy</groupId>
                     <artifactId>resteasy-client</artifactId>
-                    <version>3.0.4.Final</version>
+                    <version>3.0.5.Final</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>
                     <groupId>org.jboss.resteasy</groupId>
                     <artifactId>resteasy-jaxb-provider</artifactId>
-                    <version>3.0.4.Final</version>
+                    <version>3.0.5.Final</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-json-p-provider</artifactId>
+                    <version>3.0.5.Final</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>


### PR DESCRIPTION
The RESTEasy JSON-P Provider is required on Client side
to use the Json.createObjectBuidler API's.

Upgrade to RESTEasy 3.0.5.Final

Note: in WildFly Beta1 the Server side does not fully support the return of an JsonObject so the test still fails. This is fixed in WildFly master.
