### PR TITLE
Fix Binary WebSocket Tests for WildFly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,9 +245,9 @@
             </properties>
             <dependencies>
                 <dependency>
-                    <groupId>org.wildfly</groupId>
-                    <artifactId>wildfly-arquillian-container-managed</artifactId>
-                    <version>${org.wildfly}</version>
+                    <groupId>io.undertow</groupId>
+                    <artifactId>undertow-websockets-jsr</artifactId>
+                    <version>1.0.0.Beta25</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>
@@ -260,6 +260,12 @@
                     <groupId>org.jboss.resteasy</groupId>
                     <artifactId>resteasy-jaxb-provider</artifactId>
                     <version>3.0.4.Final</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.wildfly</groupId>
+                    <artifactId>wildfly-arquillian-container-managed</artifactId>
+                    <version>${org.wildfly}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -315,9 +321,9 @@
             <id>wildfly-remote-arquillian</id>
             <dependencies>
                 <dependency>
-                    <groupId>org.wildfly</groupId>
-                    <artifactId>wildfly-arquillian-container-remote</artifactId>
-                    <version>${org.wildfly}</version>
+                    <groupId>io.undertow</groupId>
+                    <artifactId>undertow-websockets-jsr</artifactId>
+                    <version>1.0.0.Beta25</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>
@@ -330,6 +336,12 @@
                     <groupId>org.jboss.resteasy</groupId>
                     <artifactId>resteasy-jaxb-provider</artifactId>
                     <version>3.0.4.Final</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.wildfly</groupId>
+                    <artifactId>wildfly-arquillian-container-remote</artifactId>
+                    <version>${org.wildfly}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>

--- a/websocket/binary/src/main/java/org/javaee7/websocket/binary/MyEndpointClient.java
+++ b/websocket/binary/src/main/java/org/javaee7/websocket/binary/MyEndpointClient.java
@@ -5,6 +5,7 @@ package org.javaee7.websocket.binary;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.concurrent.CountDownLatch;
 
 import javax.websocket.ClientEndpoint;
 import javax.websocket.OnMessage;
@@ -17,6 +18,7 @@ import javax.websocket.Session;
  */
 @ClientEndpoint
 public class MyEndpointClient {
+    public static CountDownLatch latch;
     public static byte[] response;
 
     @OnOpen
@@ -31,5 +33,6 @@ public class MyEndpointClient {
     @OnMessage
     public void processMessage(byte[] message) {
         MyEndpointClient.response = message;
+        latch.countDown();
     }
 }

--- a/websocket/binary/src/test/java/org/javaee7/websocket/binary/test/WebsocketBinaryEndpointTest.java
+++ b/websocket/binary/src/test/java/org/javaee7/websocket/binary/test/WebsocketBinaryEndpointTest.java
@@ -3,12 +3,17 @@
  */
 package org.javaee7.websocket.binary.test;
 
-import java.io.File;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import javax.websocket.ContainerProvider;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
+import javax.websocket.ContainerProvider;
 import javax.websocket.DeploymentException;
 import javax.websocket.Session;
 import javax.websocket.WebSocketContainer;
@@ -22,7 +27,6 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -62,10 +66,10 @@ public class WebsocketBinaryEndpointTest {
      */
     @Test
     public void testEndpointByteBuffer() throws URISyntaxException, DeploymentException, IOException, InterruptedException {
+        MyEndpointClient.latch = new CountDownLatch(1);
         Session session = connectToServer("bytebuffer");
         assertNotNull(session);
-        System.out.println("Waiting for 2 seconds to receive response");
-        Thread.sleep(2000);
+        assertTrue(MyEndpointClient.latch.await(2, TimeUnit.SECONDS));
         assertNotNull(MyEndpointClient.response);
         assertArrayEquals(RESPONSE.getBytes(), MyEndpointClient.response);
     }
@@ -81,10 +85,10 @@ public class WebsocketBinaryEndpointTest {
      */
     @Test
     public void testEndpointByteArray() throws DeploymentException, IOException, URISyntaxException, InterruptedException {
+        MyEndpointClient.latch = new CountDownLatch(1);
         Session session = connectToServer("bytearray");
         assertNotNull(session);
-        System.out.println("Waiting for 2 seconds to receive response");
-        Thread.sleep(2000);
+        assertTrue(MyEndpointClient.latch.await(2, TimeUnit.SECONDS));
         assertNotNull(MyEndpointClient.response);
         assertArrayEquals(RESPONSE.getBytes(), MyEndpointClient.response);
     }
@@ -100,10 +104,10 @@ public class WebsocketBinaryEndpointTest {
      */
     @Test
     public void testEndpointInputStream() throws DeploymentException, IOException, URISyntaxException, InterruptedException {
+        MyEndpointClient.latch = new CountDownLatch(1);
         Session session = connectToServer("inputstream");
         assertNotNull(session);
-        System.out.println("Waiting for 2 seconds to receive response");
-        Thread.sleep(2000);
+        assertTrue(MyEndpointClient.latch.await(2, TimeUnit.SECONDS));
         assertNotNull(MyEndpointClient.response);
         assertArrayEquals(RESPONSE.getBytes(), MyEndpointClient.response);
     }
@@ -127,8 +131,6 @@ public class WebsocketBinaryEndpointTest {
                         + "/"
                         + base.getPath()
                         + "/"
-
-//                "localhost:8080/binary/""
                         + endpoint);
         System.out.println("Connecting to: " + uri);
         return container.connectToServer(MyEndpointClient.class, uri);

--- a/websocket/pom.xml
+++ b/websocket/pom.xml
@@ -46,18 +46,4 @@
         <module>whiteboard</module>
         <module>endpoint-singleton</module>
     </modules>
-	<dependencies>
-		<dependency>
-            <groupId>io.undertow</groupId>
-            <artifactId>undertow-core</artifactId>
-            <version>1.0.0.Beta20</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-        	<groupId>io.undertow</groupId>
-        	<artifactId>undertow-websockets-jsr</artifactId>
-        	<version>1.0.0.Beta20</version>
-        	<scope>test</scope>
-        </dependency>
-	</dependencies>
 </project>


### PR DESCRIPTION
- Upgrade to Undertow 1.0.0.Beta25
- Move Undertow dependency from WebSocket parent to global profile
- Rewrite Tests to use on Concurrency Latches not Thread.sleep
