### PR TITLE
Clean up WebSocket tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,12 @@
                     <scope>test</scope>
                 </dependency>
                 <dependency>
+                   <groupId>org.glassfish</groupId>
+                   <artifactId>javax.json</artifactId>
+                   <version>1.0.4</version>
+                   <scope>test</scope>
+                </dependency>
+                <dependency>
                     <groupId>org.glassfish.tyrus</groupId>
                     <artifactId>tyrus-client</artifactId>
                     <version>1.3</version>
@@ -236,6 +242,12 @@
         <profile>
             <id>glassfish-remote-arquillian</id>
             <dependencies>
+                <dependency>
+                   <groupId>org.glassfish</groupId>
+                   <artifactId>javax.json</artifactId>
+                   <version>1.0.4</version>
+                   <scope>test</scope>
+                </dependency>
                 <dependency>
                     <groupId>org.glassfish.tyrus</groupId>
                     <artifactId>tyrus-client</artifactId>

--- a/websocket/encoder-client/src/main/java/org/javaee7/websocket/encoder/client/MyClient.java
+++ b/websocket/encoder-client/src/main/java/org/javaee7/websocket/encoder/client/MyClient.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import javax.websocket.ClientEndpoint;
 import javax.websocket.EncodeException;
 import javax.websocket.OnError;
@@ -57,6 +58,7 @@ import javax.websocket.Session;
         decoders={MyMessageDecoder.class})
 public class MyClient {
     public static CountDownLatch latch= new CountDownLatch(3);
+    public static MyMessage response;
     
     @OnOpen
     public void onOpen(Session session) {
@@ -69,9 +71,9 @@ public class MyClient {
     }
     
     @OnMessage
-    public MyMessage processMessage(MyMessage message) {
-        latch.countDown();
-        return message;
+    public void processMessage(MyMessage message) {
+       response = message;
+       latch.countDown();
     }
     
     @OnError

--- a/websocket/encoder-client/src/test/java/org/javaee7/websocket/encoder/client/MyClientTest.java
+++ b/websocket/encoder-client/src/test/java/org/javaee7/websocket/encoder/client/MyClientTest.java
@@ -6,22 +6,26 @@
 
 package org.javaee7.websocket.encoder.client;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.concurrent.TimeUnit;
+
 import javax.websocket.ContainerProvider;
 import javax.websocket.DeploymentException;
-import javax.websocket.MessageHandler;
 import javax.websocket.Session;
 import javax.websocket.WebSocketContainer;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
-import static org.junit.Assert.*;
 import org.junit.runner.RunWith;
 
 /**
@@ -47,16 +51,11 @@ public class MyClientTest {
 
     @Test
     public void testEndpoint() throws URISyntaxException, DeploymentException, IOException, InterruptedException {
-        final String JSON = "{\"apple\" : \"red\", \"banana\": \"yellow\"}";
+        String JSON = "{\"apple\":\"red\",\"banana\":\"yellow\"}";
         Session session = connectToServer(MyClient.class);
         assertNotNull(session);
-        session.addMessageHandler(new MessageHandler.Whole<String>() {
-            @Override
-            public void onMessage(String text) {
-                assertEquals(JSON, text);
-            }
-        });
         assertTrue(MyClient.latch.await(2, TimeUnit.SECONDS));
+        assertEquals(JSON, MyClient.response.toString());
     }
     
     public Session connectToServer(Class endpoint) throws DeploymentException, IOException, URISyntaxException {
@@ -67,9 +66,8 @@ public class MyClientTest {
                 + base.getHost()
                 + ":"
                 + base.getPort()
-                + "/"
                 + base.getPath()
-                + "/encoder-client");
+                + "encoder-client");
         return container.connectToServer(endpoint, uri);
     }
     

--- a/websocket/encoder-programmatic/src/main/java/org/javaee7/websocket/encoder/programmatic/MyClient.java
+++ b/websocket/encoder-programmatic/src/main/java/org/javaee7/websocket/encoder/programmatic/MyClient.java
@@ -17,7 +17,8 @@ import javax.websocket.Session;
 @ClientEndpoint(encoders = {MyMessageEncoder.class},
         decoders={MyMessageDecoder.class})
 public class MyClient {
-    public static CountDownLatch latch= new CountDownLatch(4);
+    public static CountDownLatch latch= new CountDownLatch(3);
+    public static MyMessage response;
     
     @OnOpen
     public void onOpen(Session session) {
@@ -30,9 +31,9 @@ public class MyClient {
     }
     
     @OnMessage
-    public MyMessage processMessage(MyMessage message) {
-        latch.countDown();
-        return message;
+    public void processMessage(MyMessage message) {
+       response = message;
+       latch.countDown();
     }
     
     @OnError

--- a/websocket/encoder-programmatic/src/main/java/org/javaee7/websocket/encoder/programmatic/MyEndpoint.java
+++ b/websocket/encoder-programmatic/src/main/java/org/javaee7/websocket/encoder/programmatic/MyEndpoint.java
@@ -42,6 +42,7 @@ package org.javaee7.websocket.encoder.programmatic;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import javax.websocket.Endpoint;
 import javax.websocket.EndpointConfig;
 import javax.websocket.MessageHandler;
@@ -59,7 +60,6 @@ public class MyEndpoint extends Endpoint {
             @Override
             public void onMessage(String text) {
                 try {
-                    MyClient.latch.countDown();
                     session.getBasicRemote().sendText(text);
                 } catch (IOException ex) {
                     Logger.getLogger(MyEndpoint.class.getName()).log(Level.SEVERE, null, ex);

--- a/websocket/encoder-programmatic/src/main/java/org/javaee7/websocket/encoder/programmatic/MyEndpointConfiguration.java
+++ b/websocket/encoder-programmatic/src/main/java/org/javaee7/websocket/encoder/programmatic/MyEndpointConfiguration.java
@@ -44,6 +44,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
 import javax.websocket.Decoder;
 import javax.websocket.Encoder;
 import javax.websocket.Endpoint;
@@ -65,14 +66,12 @@ public class MyEndpointConfiguration implements ServerApplicationConfig {
 
     @Override
     public Set<ServerEndpointConfig> getEndpointConfigs(Set<Class<? extends Endpoint>> set) {
-        return new HashSet<ServerEndpointConfig>() {
-            {
-                add(ServerEndpointConfig.Builder.create(MyEndpoint.class, "/encoder-programmatic")
+       Set<ServerEndpointConfig> config = new HashSet<ServerEndpointConfig>();
+       config.add(ServerEndpointConfig.Builder.create(MyEndpoint.class, "/encoder-programmatic")
                         .encoders(encoders)
                         .decoders(decoders)
                         .build());
-            }
-        };
+       return config;
     }
 
     @Override

--- a/websocket/encoder-programmatic/src/test/java/org/javaee7/websocket/encoder/programmatic/MyClientTest.java
+++ b/websocket/encoder-programmatic/src/test/java/org/javaee7/websocket/encoder/programmatic/MyClientTest.java
@@ -1,21 +1,25 @@
 package org.javaee7.websocket.encoder.programmatic;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.concurrent.TimeUnit;
+
 import javax.websocket.ContainerProvider;
 import javax.websocket.DeploymentException;
-import javax.websocket.MessageHandler;
 import javax.websocket.Session;
 import javax.websocket.WebSocketContainer;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
-import static org.junit.Assert.*;
 import org.junit.runner.RunWith;
 
 /**
@@ -31,7 +35,6 @@ public class MyClientTest {
         return ShrinkWrap.create(WebArchive.class)
                 .addClasses(MyEndpoint.class,
                         MyEndpointConfiguration.class,
-                        MyClient.class,
                         MyMessage.class,
                         MyMessageEncoder.class,
                         MyMessageDecoder.class);
@@ -39,19 +42,14 @@ public class MyClientTest {
 
     @Test
     public void testEndpoint() throws URISyntaxException, DeploymentException, IOException, InterruptedException {
-        final String JSON = "{\"apple\" : \"red\", \"banana\": \"yellow\"}";
+        final String JSON = "{\"apple\":\"red\",\"banana\":\"yellow\"}";
         Session session = connectToServer(MyClient.class);
         assertNotNull(session);
-        session.addMessageHandler(new MessageHandler.Whole<String>() {
-            @Override
-            public void onMessage(String text) {
-                assertEquals(JSON, text);
-            }
-        });
         assertTrue(MyClient.latch.await(2, TimeUnit.SECONDS));
+        assertEquals(JSON, MyClient.response.toString());
     }
     
-    public Session connectToServer(Class endpoint) throws DeploymentException, IOException, URISyntaxException {
+    public Session connectToServer(Class<?> endpoint) throws DeploymentException, IOException, URISyntaxException {
         WebSocketContainer container = ContainerProvider.getWebSocketContainer();
         assertNotNull(container);
         assertNotNull(base);
@@ -59,9 +57,8 @@ public class MyClientTest {
                 + base.getHost()
                 + ":"
                 + base.getPort()
-                + "/"
                 + base.getPath()
-                + "/encoder-programmatic");
+                + "encoder-programmatic");
         return container.connectToServer(endpoint, uri);
     }
     

--- a/websocket/encoder/src/main/java/org/javaee7/websocket/encoder/MyEndpointClientEmptyJSONArray.java
+++ b/websocket/encoder/src/main/java/org/javaee7/websocket/encoder/MyEndpointClientEmptyJSONArray.java
@@ -15,7 +15,8 @@ import javax.websocket.Session;
 @ClientEndpoint
 public class MyEndpointClientEmptyJSONArray {
     public static String JSON = "{}";
-    public static CountDownLatch latch= new CountDownLatch(3);
+    public static CountDownLatch latch= new CountDownLatch(1);
+    public static String response;
 
     @OnOpen
     public void onOpen(Session session) {
@@ -27,8 +28,8 @@ public class MyEndpointClientEmptyJSONArray {
     }
     
     @OnMessage
-    public String processMessage(String message) {
+    public void processMessage(String message) {
+        response = message;
         latch.countDown();
-        return message;
     }
 }

--- a/websocket/encoder/src/main/java/org/javaee7/websocket/encoder/MyEndpointClientJSONObject.java
+++ b/websocket/encoder/src/main/java/org/javaee7/websocket/encoder/MyEndpointClientJSONObject.java
@@ -14,8 +14,9 @@ import javax.websocket.Session;
  */
 @ClientEndpoint
 public class MyEndpointClientJSONObject {
-    public static CountDownLatch latch = new CountDownLatch(3);
+    public static CountDownLatch latch = new CountDownLatch(1);
     public static String JSON = "{\"apple\" : \"red\", \"banana\": \"yellow\"}";
+    public static String response;
 
     @OnOpen
     public void onOpen(Session session) {
@@ -27,8 +28,8 @@ public class MyEndpointClientJSONObject {
     }
     
     @OnMessage
-    public String processMessage(String message) {
+    public void processMessage(String message) {
+        response = message;
         latch.countDown();
-        return message;
     }
 }

--- a/websocket/encoder/src/main/java/org/javaee7/websocket/encoder/MyMessageDecoder.java
+++ b/websocket/encoder/src/main/java/org/javaee7/websocket/encoder/MyMessageDecoder.java
@@ -52,12 +52,6 @@ public class MyMessageDecoder implements Decoder.Text<MyMessage> {
 
     @Override
     public MyMessage decode(String string) throws DecodeException {
-        if (MyEndpointClientEmptyJSONArray.latch != null)
-            MyEndpointClientEmptyJSONArray.latch.countDown();
-        
-        if (MyEndpointClientJSONObject.latch != null)
-            MyEndpointClientJSONObject.latch.countDown();
-        
         MyMessage myMessage = new MyMessage(Json.createReader(new StringReader(string)).readObject());
         return myMessage;
     }

--- a/websocket/encoder/src/main/java/org/javaee7/websocket/encoder/MyMessageEncoder.java
+++ b/websocket/encoder/src/main/java/org/javaee7/websocket/encoder/MyMessageEncoder.java
@@ -49,12 +49,6 @@ import javax.websocket.EndpointConfig;
 public class MyMessageEncoder implements Encoder.Text<MyMessage> {
     @Override
     public String encode(MyMessage myMessage) throws EncodeException {
-        if (MyEndpointClientEmptyJSONArray.latch != null)
-            MyEndpointClientEmptyJSONArray.latch.countDown();
-        
-        if (MyEndpointClientJSONObject.latch != null)
-            MyEndpointClientJSONObject.latch.countDown();
-        
         return myMessage.getJsonObject().toString();
     }
 

--- a/websocket/encoder/src/test/java/org/javaee7/websocket/encoder/EncoderEndpointTest.java
+++ b/websocket/encoder/src/test/java/org/javaee7/websocket/encoder/EncoderEndpointTest.java
@@ -1,17 +1,16 @@
 package org.javaee7.websocket.encoder;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import javax.websocket.ContainerProvider;
 import javax.websocket.DeploymentException;
-import javax.websocket.MessageHandler;
 import javax.websocket.Session;
 import javax.websocket.WebSocketContainer;
 
@@ -43,36 +42,24 @@ public class EncoderEndpointTest {
                 .addClasses(MyEndpoint.class,
                         MyMessage.class,
                         MyMessageEncoder.class,
-                        MyMessageDecoder.class,
-                        MyEndpointClientEmptyJSONArray.class,
-                        MyEndpointClientJSONObject.class);
+                        MyMessageDecoder.class);
     }
 
     @Test
     public void testEndpointEmptyJSONArray() throws URISyntaxException, DeploymentException, IOException, InterruptedException {
         final Session session = connectToServer(MyEndpointClientEmptyJSONArray.class);
         assertNotNull(session);
-        session.addMessageHandler(new MessageHandler.Whole<String>() {
-            @Override
-            public void onMessage(String text) {
-                assertEquals("{}", text);
-            }
-        });
         assertTrue(MyEndpointClientEmptyJSONArray.latch.await(2, TimeUnit.SECONDS));
+        assertEquals("{}", MyEndpointClientEmptyJSONArray.response);
     }
 
     @Test
     public void testEndpointEmptyJSONObject() throws URISyntaxException, DeploymentException, IOException, InterruptedException {
-        final String JSON = "{\"apple\" : \"red\", \"banana\": \"yellow\"}";
+        String JSON = "{\"apple\":\"red\",\"banana\":\"yellow\"}";
         Session session = connectToServer(MyEndpointClientJSONObject.class);
         assertNotNull(session);
-        session.addMessageHandler(new MessageHandler.Whole<String>() {
-            @Override
-            public void onMessage(String text) {
-                assertEquals(JSON, text);
-            }
-        });
         assertTrue(MyEndpointClientJSONObject.latch.await(2, TimeUnit.SECONDS));
+        assertEquals(JSON, MyEndpointClientJSONObject.response);
     }
 
     /**
@@ -85,15 +72,14 @@ public class EncoderEndpointTest {
      * @throws IOException
      * @throws URISyntaxException
      */
-    public Session connectToServer(Class endpoint) throws DeploymentException, IOException, URISyntaxException {
+    public Session connectToServer(Class<?> endpoint) throws DeploymentException, IOException, URISyntaxException {
         WebSocketContainer container = ContainerProvider.getWebSocketContainer();
         URI uri = new URI("ws://"
                 + base.getHost()
                 + ":"
                 + base.getPort()
-                + "/"
                 + base.getPath()
-                + "/encoder");
+                + "encoder");
         return container.connectToServer(endpoint, uri);
     }
 }

--- a/websocket/endpoint-programmatic/src/test/java/org/javaee7/websocket/endpoint/programmatic/MyEndpointTest.java
+++ b/websocket/endpoint-programmatic/src/test/java/org/javaee7/websocket/endpoint/programmatic/MyEndpointTest.java
@@ -70,15 +70,14 @@ public class MyEndpointTest {
         assertTrue(MyEndpointBinaryClient.latch.await(2, TimeUnit.SECONDS));
     }
 
-    public Session connectToServer(Class endpoint) throws DeploymentException, IOException, URISyntaxException {
+    public Session connectToServer(Class<?> endpoint) throws DeploymentException, IOException, URISyntaxException {
         WebSocketContainer container = ContainerProvider.getWebSocketContainer();
         URI uri = new URI("ws://"
                         + base.getHost()
                         + ":"
                         + base.getPort()
-                        + "/"
                         + base.getPath()
-                        + "/websocket");
+                        + "websocket");
         System.out.println("Connecting to: " + uri);
         return container.connectToServer(endpoint, uri);
     }

--- a/websocket/endpoint/src/main/java/org/javaee7/websocket/endpoint/MyEndpointTextClient.java
+++ b/websocket/endpoint/src/main/java/org/javaee7/websocket/endpoint/MyEndpointTextClient.java
@@ -14,11 +14,12 @@ import javax.websocket.Session;
 @ClientEndpoint
 public class MyEndpointTextClient {
     public static CountDownLatch latch;
+    public static String response;
 
     @OnOpen
     public void onOpen(Session session) {
         try {
-            session.getBasicRemote().sendText("Hello world!");
+            session.getBasicRemote().sendText("Hello World!");
         } catch (IOException ioe) {
             ioe.printStackTrace();
         }
@@ -26,6 +27,7 @@ public class MyEndpointTextClient {
     
     @OnMessage
     public void processMessage(String message) {
+        response = message;
         latch.countDown();
     }
 }

--- a/websocket/endpoint/src/test/java/org/javaee7/websocket/endpoint/MyEndpointTest.java
+++ b/websocket/endpoint/src/test/java/org/javaee7/websocket/endpoint/MyEndpointTest.java
@@ -1,23 +1,27 @@
 package org.javaee7.websocket.endpoint;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.ByteBuffer;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+
 import javax.websocket.ContainerProvider;
 import javax.websocket.DeploymentException;
-import javax.websocket.MessageHandler;
 import javax.websocket.Session;
 import javax.websocket.WebSocketContainer;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
-import static org.junit.Assert.*;
 import org.junit.runner.RunWith;
 
 /**
@@ -46,16 +50,10 @@ public class MyEndpointTest {
     @Test
     public void testTextEndpoint() throws URISyntaxException, DeploymentException, IOException, InterruptedException {
         MyEndpointTextClient.latch = new CountDownLatch(1);
-        Session session = connectToServer(MyEndpointTextClient.class, "/text");
+        Session session = connectToServer(MyEndpointTextClient.class, "text");
         assertNotNull(session);
-        session.addMessageHandler(new MessageHandler.Whole<String>() {
-            @Override
-            public void onMessage(String text) {
-                MyEndpointTextClient.latch.countDown();
-                assertEquals(TEXT, text);
-            }
-        });
         assertTrue(MyEndpointTextClient.latch.await(2, TimeUnit.SECONDS));
+        assertEquals(TEXT, MyEndpointTextClient.response);
     }
     
     @Test
@@ -88,16 +86,14 @@ public class MyEndpointTest {
     }
     
     
-    public Session connectToServer(Class endpoint, String uriPart) throws DeploymentException, IOException, URISyntaxException {
+    public Session connectToServer(Class<?> endpoint, String uriPart) throws DeploymentException, IOException, URISyntaxException {
         WebSocketContainer container = ContainerProvider.getWebSocketContainer();
         URI uri = new URI("ws://"
-                        + base.getHost()
-                        + ":"
-                        + base.getPort()
-                        + "/"
-                        + base.getPath()
-                        + "/"
-                        + uriPart);
+              + base.getHost()
+              + ":"
+              + base.getPort()
+              + base.getPath()
+              + uriPart);
         System.out.println("Connecting to: " + uri);
         return container.connectToServer(endpoint, uri);
     }


### PR DESCRIPTION
- Remove recursive send/receive.
- Correct the CountDownLatch count numbers. Mixes between Client and
  Server Encoder/Decoders and rely on multiple messages being echoed.
- GlassFish is more sensible to double slashes in WS URL's. Remove
  the extra forward slashes.
- Pr spec you can only register a single Message Handler pr type. Change
  to store Message in static to verify content.
