### PR TITLE
Remove MessageBodyReader from Client

### DIFF
--- a/jaxrs/readerwriter-injection/pom.xml
+++ b/jaxrs/readerwriter-injection/pom.xml
@@ -8,8 +8,6 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
         
-    <groupId>org.javaee7.jaxrs</groupId>
     <artifactId>readerwriter-injection</artifactId>
-    <version>1.0-SNAPSHOT</version>
     <packaging>war</packaging>
 </project>

--- a/jaxrs/readerwriter-injection/src/main/java/org/javaee7/jaxrs/readerwriter/injection/MyObject.java
+++ b/jaxrs/readerwriter-injection/src/main/java/org/javaee7/jaxrs/readerwriter/injection/MyObject.java
@@ -45,6 +45,8 @@ import java.io.Serializable;
  * @author Arun Gupta
  */
 public class MyObject implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     public static final String MIME_TYPE = "application/myType";
 
     private int index;

--- a/jaxrs/readerwriter-injection/src/main/java/org/javaee7/jaxrs/readerwriter/injection/MyReader.java
+++ b/jaxrs/readerwriter-injection/src/main/java/org/javaee7/jaxrs/readerwriter/injection/MyReader.java
@@ -46,9 +46,8 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import javax.inject.Inject;
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;

--- a/jaxrs/readerwriter-injection/src/test/java/org/javaee7/jaxrs/readerwriter/injection/MyResourceTest.java
+++ b/jaxrs/readerwriter-injection/src/test/java/org/javaee7/jaxrs/readerwriter/injection/MyResourceTest.java
@@ -5,12 +5,17 @@
  */
 package org.javaee7.jaxrs.readerwriter.injection;
 
+import static org.junit.Assert.assertEquals;
+
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
+
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -19,7 +24,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import static org.junit.Assert.*;
 import org.junit.runner.RunWith;
 
 /**
@@ -37,10 +41,8 @@ public class MyResourceTest {
     @Before
     public void setUp() throws MalformedURLException {
         client = ClientBuilder.newClient();
-        client
-                .register(MyReader.class)
-                .register(MyWriter.class);
-        target = client.target(new URL(base, "webresources/fruits").toExternalForm());
+        client.register(MyWriter.class);
+        target = client.target(URI.create(new URL(base, "webresources/fruits").toExternalForm()));
     }
 
     @After


### PR DESCRIPTION
MyReader rely on CDI Injection which is not available on the
the Client side of JAX-RS.
