### PR TITLE
httpclient local dependency removed

### DIFF
--- a/jaspic/pom.xml
+++ b/jaspic/pom.xml
@@ -34,13 +34,4 @@
         <module>wrapping</module>
     </modules>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.2.1</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
-
 </project>


### PR DESCRIPTION
Httpclient is now a dependency in the global pom.xml
