### PR TITLE
Added tests for using an @DataSourceDefinition data source with JPA

### DIFF
--- a/jpa/datasourcedefinition-annotation-pu/pom.xml
+++ b/jpa/datasourcedefinition-annotation-pu/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    
+    <parent>
+        <groupId>org.javaee7.jpa</groupId>
+        <artifactId>jpa-samples</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>datasourcedefinition-annotation-pu</artifactId>
+    <packaging>war</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>1.3.173</version>
+        </dependency>
+    </dependencies>
+    
+</project>

--- a/jpa/datasourcedefinition-annotation-pu/src/main/java/org/javaee7/jpa/datasourcedefinition_annotation_pu/config/DataSourceDefinitionConfig.java
+++ b/jpa/datasourcedefinition-annotation-pu/src/main/java/org/javaee7/jpa/datasourcedefinition_annotation_pu/config/DataSourceDefinitionConfig.java
@@ -1,0 +1,13 @@
+package org.javaee7.jpa.datasourcedefinition_annotation_pu.config;
+
+import javax.annotation.sql.DataSourceDefinition;
+import javax.ejb.Stateless;
+
+@DataSourceDefinition(
+    name = "java:app/MyApp/MyDS", 
+    className = "org.h2.jdbcx.JdbcDataSource", 
+    url = "jdbc:h2:mem:test"
+)
+@Stateless
+public class DataSourceDefinitionConfig {
+}

--- a/jpa/datasourcedefinition-annotation-pu/src/main/java/org/javaee7/jpa/datasourcedefinition_annotation_pu/entity/TestEntity.java
+++ b/jpa/datasourcedefinition-annotation-pu/src/main/java/org/javaee7/jpa/datasourcedefinition_annotation_pu/entity/TestEntity.java
@@ -1,0 +1,39 @@
+package org.javaee7.jpa.datasourcedefinition_annotation_pu.entity;
+
+import static javax.persistence.GenerationType.IDENTITY;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+/**
+ * A very simple JPA entity that will be used for testing
+ * 
+ * @author Arjan Tijms
+ *
+ */
+@Entity
+public class TestEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+    private String value;
+    
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+    
+}

--- a/jpa/datasourcedefinition-annotation-pu/src/main/java/org/javaee7/jpa/datasourcedefinition_annotation_pu/service/TestService.java
+++ b/jpa/datasourcedefinition-annotation-pu/src/main/java/org/javaee7/jpa/datasourcedefinition_annotation_pu/service/TestService.java
@@ -1,0 +1,40 @@
+package org.javaee7.jpa.datasourcedefinition_annotation_pu.service;
+
+import java.util.List;
+
+import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.javaee7.jpa.datasourcedefinition_annotation_pu.entity.TestEntity;
+
+/**
+ * This service does some JPA operations. The purpose of this entire test
+ * is just to see whether the data source can be used so the actual operations
+ * don't matter much.
+ * 
+ * @author Arjan Tijms
+ *
+ */
+@Stateless
+public class TestService {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    public void saveNewEntity() {
+        
+        TestEntity testEntity = new TestEntity();
+        testEntity.setValue("mytest");
+        
+        entityManager.persist(testEntity);
+    }
+    
+    public List<TestEntity> getAllEntities() {
+        return entityManager.createQuery("SELECT _testEntity FROM TestEntity _testEntity", TestEntity.class)
+                            .getResultList();
+    }
+
+    
+
+}

--- a/jpa/datasourcedefinition-annotation-pu/src/main/resources/META-INF/persistence.xml
+++ b/jpa/datasourcedefinition-annotation-pu/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence version="2.1" xmlns="http://xmlns.jcp.org/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
+
+    <persistence-unit name="testPU">
+
+        <!-- 
+            This data source is defined from within the application via the @DataSourceDefinition annotation on 
+            class org.javaee7.jpa.datasourcedefinition_annotation_pu.config.DataSourceDefinitionConfig
+        -->
+        <jta-data-source>java:app/MyApp/MyDS</jta-data-source>
+
+        <properties>
+            <property name="javax.persistence.schema-generation.database.action" value="drop-and-create" />
+        </properties>
+    </persistence-unit>
+    
+</persistence>

--- a/jpa/datasourcedefinition-annotation-pu/src/test/java/org/javaee7/jpa/datasourcedefinition_annotation_pu/DataSourceDefinitionAnnotationPuTest.java
+++ b/jpa/datasourcedefinition-annotation-pu/src/test/java/org/javaee7/jpa/datasourcedefinition_annotation_pu/DataSourceDefinitionAnnotationPuTest.java
@@ -1,0 +1,58 @@
+package org.javaee7.jpa.datasourcedefinition_annotation_pu;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.javaee7.jpa.datasourcedefinition_annotation_pu.config.DataSourceDefinitionConfig;
+import org.javaee7.jpa.datasourcedefinition_annotation_pu.entity.TestEntity;
+import org.javaee7.jpa.datasourcedefinition_annotation_pu.service.TestService;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * This tests that a data source defined via an annotation in {@link DataSourceDefinitionConfig} can be used by JPA. 
+ * <p>
+ * The actual JPA code being run is not specifically relevant; any kind of JPA operation that
+ * uses the data source is okay here. 
+ * 
+ * @author Arjan Tijms
+ */
+@RunWith(Arquillian.class)
+public class DataSourceDefinitionAnnotationPuTest {
+
+    @Inject
+    private TestService testService;
+    
+    @Deployment
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addPackages(true, DataSourceDefinitionAnnotationPuTest.class.getPackage())
+                .addAsResource("META-INF/persistence.xml")
+                .addAsLibraries(Maven.resolver()
+                    .loadPomFromFile("pom.xml")
+                    .resolve("com.h2database:h2")
+                    .withoutTransitivity()
+                    .asSingleFile())
+                ;
+    }
+
+    @Test
+    public void insertAndQueryEntity() throws Exception {
+        
+        testService.saveNewEntity();
+        
+        List<TestEntity> testEntities = testService.getAllEntities();
+        
+        assertTrue(testEntities.size() == 1);
+        assertTrue(testEntities.get(0).getValue().equals("mytest"));
+    }
+}

--- a/jpa/datasourcedefinition-webxml-pu/pom.xml
+++ b/jpa/datasourcedefinition-webxml-pu/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    
+    <parent>
+        <groupId>org.javaee7.jpa</groupId>
+        <artifactId>jpa-samples</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>datasourcedefinition-webxml-pu</artifactId>
+    <packaging>war</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>1.3.173</version>
+        </dependency>
+    </dependencies>
+    
+</project>

--- a/jpa/datasourcedefinition-webxml-pu/src/main/java/org/javaee7/jpa/datasourcedefinition_webxml_pu/entity/TestEntity.java
+++ b/jpa/datasourcedefinition-webxml-pu/src/main/java/org/javaee7/jpa/datasourcedefinition_webxml_pu/entity/TestEntity.java
@@ -1,0 +1,39 @@
+package org.javaee7.jpa.datasourcedefinition_webxml_pu.entity;
+
+import static javax.persistence.GenerationType.IDENTITY;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+/**
+ * A very simple JPA entity that will be used for testing
+ * 
+ * @author Arjan Tijms
+ *
+ */
+@Entity
+public class TestEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+    private String value;
+    
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+    
+}

--- a/jpa/datasourcedefinition-webxml-pu/src/main/java/org/javaee7/jpa/datasourcedefinition_webxml_pu/service/TestService.java
+++ b/jpa/datasourcedefinition-webxml-pu/src/main/java/org/javaee7/jpa/datasourcedefinition_webxml_pu/service/TestService.java
@@ -1,0 +1,40 @@
+package org.javaee7.jpa.datasourcedefinition_webxml_pu.service;
+
+import java.util.List;
+
+import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.javaee7.jpa.datasourcedefinition_webxml_pu.entity.TestEntity;
+
+/**
+ * This service does some JPA operations. The purpose of this entire test
+ * is just to see whether the data source can be used so the actual operations
+ * don't matter much.
+ * 
+ * @author Arjan Tijms
+ *
+ */
+@Stateless
+public class TestService {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    public void saveNewEntity() {
+        
+        TestEntity testEntity = new TestEntity();
+        testEntity.setValue("mytest");
+        
+        entityManager.persist(testEntity);
+    }
+    
+    public List<TestEntity> getAllEntities() {
+        return entityManager.createQuery("SELECT _testEntity FROM TestEntity _testEntity", TestEntity.class)
+                            .getResultList();
+    }
+
+    
+
+}

--- a/jpa/datasourcedefinition-webxml-pu/src/main/resources/META-INF/persistence.xml
+++ b/jpa/datasourcedefinition-webxml-pu/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence version="2.1" xmlns="http://xmlns.jcp.org/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
+
+    <persistence-unit name="testPU">
+
+        <!-- This data source is defined from within the application via the data-source element in web.xml -->
+        <jta-data-source>java:app/MyApp/MyDS</jta-data-source>
+
+        <properties>
+            <property name="javax.persistence.schema-generation.database.action" value="drop-and-create" />
+        </properties>
+    </persistence-unit>
+    
+</persistence>

--- a/jpa/datasourcedefinition-webxml-pu/src/main/webapp/WEB-INF/web.xml
+++ b/jpa/datasourcedefinition-webxml-pu/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd" version="3.1">
+
+    <!-- 
+        This defines the data source that's used by persistence.xml to back to the JPA persistence unit. 
+        The database is embedded within this application (see the pom.xml of this project).
+     -->
+    
+    <data-source>
+        <name>java:app/MyApp/MyDS</name>
+        <class-name>org.h2.jdbcx.JdbcDataSource</class-name>
+        <url>jdbc:h2:mem:test</url>
+    </data-source>
+
+</web-app>
+

--- a/jpa/datasourcedefinition-webxml-pu/src/test/java/org/javaee7/jpa/datasourcedefinition_webxml_pu/DataSourceDefinitionWebxmlPuTest.java
+++ b/jpa/datasourcedefinition-webxml-pu/src/test/java/org/javaee7/jpa/datasourcedefinition_webxml_pu/DataSourceDefinitionWebxmlPuTest.java
@@ -1,0 +1,65 @@
+package org.javaee7.jpa.datasourcedefinition_webxml_pu;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.javaee7.jpa.datasourcedefinition_webxml_pu.entity.TestEntity;
+import org.javaee7.jpa.datasourcedefinition_webxml_pu.service.TestService;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * This tests that a data source defined in web.xml can be used by JPA. 
+ * <p>
+ * The actual JPA code being run is not specifically relevant; any kind of JPA operation that
+ * uses the data source is okay here. 
+ * 
+ * @author Arjan Tijms
+ */
+@RunWith(Arquillian.class)
+public class DataSourceDefinitionWebxmlPuTest {
+    
+    private static final String WEBAPP_SRC = "src/main/webapp";
+
+    @Inject
+    private TestService testService;
+    
+    @Deployment
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addPackages(true, DataSourceDefinitionWebxmlPuTest.class.getPackage())
+                .addAsResource("META-INF/persistence.xml")
+                .addAsWebInfResource(resource("web.xml"))
+                .addAsLibraries(Maven.resolver()
+                    .loadPomFromFile("pom.xml")
+                    .resolve("com.h2database:h2")
+                    .withoutTransitivity()
+                    .asSingleFile())
+                ;
+    }
+
+    @Test
+    public void insertAndQueryEntity() throws Exception {
+        
+        testService.saveNewEntity();
+        
+        List<TestEntity> testEntities = testService.getAllEntities();
+        
+        assertTrue(testEntities.size() == 1);
+        assertTrue(testEntities.get(0).getValue().equals("mytest"));
+    }
+    
+    private static File resource(String name) {
+        return new File(WEBAPP_SRC + "/WEB-INF", name);
+    }
+}

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -16,6 +16,9 @@
 
     <modules>
         <module>criteria</module>
+        <module>datasourcedefinition</module>
+        <module>datasourcedefinition-webxml-pu</module>
+        <module>datasourcedefinition-annotation-pu</module>
         <module>dynamic-named-query</module>
         <module>entitygraph</module>
         <module>listeners</module>
@@ -35,7 +38,6 @@
         <module>unsynchronized-pc</module>
         <module>extended-pc</module>
         <module>jpa-converter</module>
-        <module>datasourcedefinition</module>
     </modules>
 
 </project>


### PR DESCRIPTION
Note that both tests fail on both GlassFish 4 and WildFly 8 cr1.

WildFly already fails at deployment time with:

ERROR [org.jboss.as.controller.management-operation](management-handler-thread - 3) JBAS014613: Operation ("deploy") failed - address: ([("deployment" => "dca783dd-b383-4a16-85a4-1331a2f89354.war")]) - failure description: {"JBAS014771: Services with missing/unavailable dependencies" => ["jboss.persistenceunit.\"dca783dd-b383-4a16-85a4-1331a2f89354.war#testPU\".**FIRST_PHASE** is missing [jboss.naming.context.java.app.dca783dd-b383-4a16-85a4-1331a2f89354.MyApp.MyDS]"]}

ERROR [org.jboss.as.server](management-handler-thread - 3) JBAS015870: Deploy of deployment "dca783dd-b383-4a16-85a4-1331a2f89354.war" was rolled back with the following failure message: {"JBAS014771: Services with missing/unavailable dependencies" => ["jboss.persistenceunit.\"dca783dd-b383-4a16-85a4-1331a2f89354.war#testPU\".**FIRST_PHASE** is missing [jboss.naming.context.java.app.dca783dd-b383-4a16-85a4-1331a2f89354.MyApp.MyDS]"]}
17:59:59,156 

While GlassFish fails at runtime with:

Caused by: org.omg.CORBA.INTERNAL: JTS5031: Exception [org.omg.CORBA.INTERNAL:   vmcid: 0x0  minor code: 0 completed: Maybe] on Resource [rollback] operation.  vmcid: 0x0  minor code: 0  completed: No
    at com.sun.jts.CosTransactions.RegisteredResources.distributeRollback(RegisteredResources.java:1187)
    at com.sun.jts.CosTransactions.TopCoordinator.rollback(TopCoordinator.java:2291)
    at com.sun.jts.CosTransactions.CoordinatorTerm.rollback(CoordinatorTerm.java:530)
    at com.sun.jts.CosTransactions.TerminatorImpl.rollback(TerminatorImpl.java:286)
    at com.sun.jts.jta.TransactionImpl.rollback(TransactionImpl.java:162)
    ... 126 more

WARNING: RAR5035:Unexpected exception while destroying resource from pool __SYSTEM/pools/__datasource_definition/5f110772-6547-4c6e-9d56-1a437f052bd8/java:app/MyApp/MyDS. Exception message: This web container has not yet been started

Very similar code does run on JBoss EAP 6 and GlassFish 3.
