### PR TITLE
Add jboss-web.xml to web deployments

### DIFF
--- a/jaspic/basic-authentication/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/jaspic/basic-authentication/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+
+<jboss-web>
+    <security-domain>jaspitest</security-domain>
+</jboss-web>

--- a/jaspic/common/src/main/java/org/javaee7/jaspic/common/ArquillianBase.java
+++ b/jaspic/common/src/main/java/org/javaee7/jaspic/common/ArquillianBase.java
@@ -16,7 +16,8 @@ public class ArquillianBase {
 
     public static WebArchive defaultArchive() {
         return ShrinkWrap.create(WebArchive.class).addPackages(true, "org.javaee7.jaspic")
-                .addAsWebInfResource(resource("web.xml")).addAsWebInfResource(resource("glassfish-web.xml"));
+                .addAsWebInfResource(resource("web.xml")).addAsWebInfResource(resource("glassfish-web.xml"))
+                .addAsWebInfResource(resource("jboss-web.xml"));
     }
 
     private static File resource(String name) {

--- a/jaspic/ejb-propagation/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/jaspic/ejb-propagation/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+
+<jboss-web>
+    <security-domain>jaspitest</security-domain>
+</jboss-web>

--- a/jaspic/lifecycle/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/jaspic/lifecycle/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+
+<jboss-web>
+    <security-domain>jaspitest</security-domain>
+</jboss-web>

--- a/jaspic/register-session/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/jaspic/register-session/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+
+<jboss-web>
+    <security-domain>jaspitest</security-domain>
+</jboss-web>

--- a/jaspic/wrapping/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/jaspic/wrapping/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+
+<jboss-web>
+    <security-domain>jaspitest</security-domain>
+</jboss-web>


### PR DESCRIPTION
This is needed to link the webapps to the security domain "jaspitest". We are currently reviewing the JASPIC configuration and we might remove the need for a security domain (in which case we can remove the jboss-web.xml files this commit is adding).

As of now we must configure a jaspitest security domain in standalone.xml to enable JASPIC before running the tests. This is how the domain looks like

<security-domain name="jaspitest" cache-type="default">
    <authentication-jaspi>
        <login-module-stack name="dummy">
            <login-module code="Dummy" flag="optional"/>
        </login-module-stack>
        <auth-module code="Dummy"/>
    </authentication-jaspi>
</security-domain>
