### PR TITLE
JMS Batch sample

### DIFF
--- a/jms/jms-batch/pom.xml
+++ b/jms/jms-batch/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.javaee7.jms</groupId>
+        <artifactId>jms-samples</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jms-batch</artifactId>
+
+    <name>Batch JMS processing</name>
+    <description>ItemReader reading from durable subscription</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.javaee7</groupId>
+            <artifactId>util-samples</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/jms/jms-batch/src/main/java/org/javaee7/jms/batch/JmsItemReader.java
+++ b/jms/jms-batch/src/main/java/org/javaee7/jms/batch/JmsItemReader.java
@@ -1,0 +1,47 @@
+package org.javaee7.jms.batch;
+
+import javax.annotation.Resource;
+import javax.batch.api.chunk.AbstractItemReader;
+import javax.inject.Named;
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSConsumer;
+import javax.jms.JMSContext;
+import javax.jms.Topic;
+import java.io.Serializable;
+
+/**
+ * @author Patrik Dudits
+ */
+@Named
+public class JmsItemReader extends AbstractItemReader {
+
+    @Resource(lookup = Resources.CONNECTION_FACTORY)
+    ConnectionFactory factory;
+
+    private JMSContext jms;
+
+    @Resource(lookup = Resources.TOPIC)
+    Topic topic;
+
+    private JMSConsumer subscription;
+
+    @Override
+    public void open(Serializable checkpoint) throws Exception {
+        jms = factory.createContext(); // <1> Since we're not using default connection factory, we use app managed +JMSContext+
+        subscription = jms.createDurableConsumer(topic, Resources.SUBSCRIPTION);
+    }
+
+    @Override
+    public Object readItem() throws Exception {
+        Integer item = subscription.receiveBodyNoWait(Integer.class); // <2> When there is no message ready to be received, +null+ is returned, fulfilling +readItem+ contract
+        return item;
+    }
+
+    @Override
+    public void close() throws Exception {
+        subscription.close(); // <3> Free resources at end of run
+        jms.close();
+    }
+
+
+}

--- a/jms/jms-batch/src/main/java/org/javaee7/jms/batch/Resources.java
+++ b/jms/jms-batch/src/main/java/org/javaee7/jms/batch/Resources.java
@@ -1,0 +1,25 @@
+package org.javaee7.jms.batch;
+
+import javax.jms.JMSConnectionFactoryDefinition;
+import javax.jms.JMSDestinationDefinition;
+
+/**
+ * @author Patrik Dudits
+ */
+@JMSDestinationDefinition(
+        name = Resources.TOPIC,
+        resourceAdapter = "jmsra",
+        interfaceName = "javax.jms.Topic",
+        destinationName="batch.topic",
+        description="Batch processing topic")
+@JMSConnectionFactoryDefinition( // <1> WildFly appears to require user and password to be set for connection factories
+        name = Resources.CONNECTION_FACTORY,
+        resourceAdapter =  "jmsra",
+        clientId = "batchJob", // <2> It is not allowed to call +setClientId+ on +Connection+ or +JMSContext+ in Java EE container.
+        description = "Connection factory with clientId of the durable subscription"
+)
+public class Resources {
+    public static final String SUBSCRIPTION = "BatchJob"; // <3> Durable consumer is uniquely identified with its +clientId+ and +subscriptionName+.
+    public static final String TOPIC = "java:app/batch/topic";
+    public static final String CONNECTION_FACTORY = "java:app/batch/factory";
+}

--- a/jms/jms-batch/src/main/java/org/javaee7/jms/batch/ResultCollector.java
+++ b/jms/jms-batch/src/main/java/org/javaee7/jms/batch/ResultCollector.java
@@ -1,0 +1,32 @@
+package org.javaee7.jms.batch;
+
+import javax.ejb.Singleton;
+
+/**
+ * @author Patrik Dudits
+ */
+@Singleton
+public class ResultCollector {
+
+    private int numberOfJobs;
+    private int lastItemCount;
+    private int lastSum;
+
+    public void postResult(int sum, int numItems) {
+        numberOfJobs++;
+        lastItemCount = numItems;
+        lastSum = sum;
+    }
+
+    public int getNumberOfJobs() {
+        return numberOfJobs;
+    }
+
+    public int getLastItemCount() {
+        return lastItemCount;
+    }
+
+    public int getLastSum() {
+        return lastSum;
+    }
+}

--- a/jms/jms-batch/src/main/java/org/javaee7/jms/batch/SubscriptionCreator.java
+++ b/jms/jms-batch/src/main/java/org/javaee7/jms/batch/SubscriptionCreator.java
@@ -1,0 +1,42 @@
+package org.javaee7.jms.batch;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSConsumer;
+import javax.jms.JMSContext;
+import javax.jms.Topic;
+
+/**
+ * Create durable subscription upon deployment.
+ *
+ * Durable subscription needs unique subscription name and client id. Since setting
+ * client id is not possible in Java EE environment, we define app-specific connection
+ * factory with a client id.
+ *
+ * @author Patrik Dudits
+ */
+@Singleton
+@Startup
+public class SubscriptionCreator {
+
+    @Resource(lookup = Resources.TOPIC)
+    Topic topic;
+
+    @Resource(lookup = Resources.CONNECTION_FACTORY)
+    ConnectionFactory factory;
+
+    /**
+     * We create the subscription at soonest possible time after deployment so we
+     * wouldn't miss any message
+     */
+    @PostConstruct
+    void createSubscription() {
+        try (JMSContext jms = factory.createContext()) { // <1> This is factory with clientId specified
+            JMSConsumer consumer = jms.createDurableConsumer(topic, Resources.SUBSCRIPTION); // <2> creates durable subscription on the topic
+            consumer.close();
+        }
+    }
+}

--- a/jms/jms-batch/src/main/java/org/javaee7/jms/batch/SummingItemWriter.java
+++ b/jms/jms-batch/src/main/java/org/javaee7/jms/batch/SummingItemWriter.java
@@ -1,0 +1,44 @@
+package org.javaee7.jms.batch;
+
+import javax.batch.api.chunk.AbstractItemWriter;
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * @author Patrik Dudits
+ */
+@Named
+public class SummingItemWriter extends AbstractItemWriter {
+    @Inject
+    ResultCollector collector;
+
+    private int numItems;
+    private int sum;
+
+    @Override
+    public void open(Serializable checkpoint) throws Exception {
+        numItems = 0; // <1> Reset the computation
+        sum = 0;
+    }
+
+    @Override
+    public void writeItems(List<Object> objects) throws Exception {
+        numItems += objects.size(); // <2> Perform the computation. Note that this may be called multiple times within single job run
+        sum += computeSum(objects);
+    }
+
+    @Override
+    public void close() throws Exception {
+        collector.postResult(sum, numItems); // <3> Post results
+    }
+
+    private int computeSum(List<Object> objects) {
+        int subTotal = 0;
+        for (Object o : objects) {
+            subTotal += (Integer)o;
+        }
+        return subTotal;
+    }
+}

--- a/jms/jms-batch/src/main/resources/META-INF/batch-jobs/jms-job.xml
+++ b/jms/jms-batch/src/main/resources/META-INF/batch-jobs/jms-job.xml
@@ -1,0 +1,8 @@
+<job id="jms-job" xmlns="http://xmlns.jcp.org/xml/ns/javaee" version="1.0">
+    <step id="step1" >
+        <chunk>
+            <reader ref="jmsItemReader"/>
+            <writer ref="summingItemWriter"/>
+        </chunk>
+    </step>
+</job>

--- a/jms/jms-batch/src/test/java/org/javaee7/jms/batch/JmsItemReaderTest.java
+++ b/jms/jms-batch/src/test/java/org/javaee7/jms/batch/JmsItemReaderTest.java
@@ -1,0 +1,139 @@
+package org.javaee7.jms.batch;
+
+import org.javaee7.util.BatchTestHelper;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.shrinkwrap.api.ArchivePaths;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.annotation.Resource;
+import javax.batch.operations.JobOperator;
+import javax.batch.runtime.BatchRuntime;
+import javax.batch.runtime.JobExecution;
+import javax.ejb.EJB;
+import javax.jms.*;
+import java.util.Properties;
+import java.util.Random;
+
+import static org.junit.Assert.*;
+
+/**
+ * This test demonstrates programmatical creation of durable consumer, and reading
+ * its subscribed messages in a batch job in form of an +ItemReader+.
+ *
+ * include::JmsItemReader[]
+ *
+ * The items are then fed into the writer, that performs the aggregation and stores
+ * the result into a +@Singleton+ EJB.
+ *
+ * include::SummingItemWriter[]
+ *
+ * @author Patrik Dudits
+ */
+@RunWith(Arquillian.class)
+public class JmsItemReaderTest {
+
+    /**
+     * Upon deployment a topic and connection factory for durable subscription are created:
+     *
+     * include::Resources[]
+     *
+     * Then the subscription itself is created by means of +@Singleton+ +@Startup+ EJB
+     * +SubscriptionCreator+.
+     *
+     * include::SubscriptionCreator#createSubscription[]
+     *
+     * The job itself computes sum and count of random numbers that are send on the topic.
+     * Note that at time of sending there is no active consumer listening on the topic.
+     */
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, ArchivePaths.create("beans.xml"))
+                .addClass(BatchTestHelper.class)
+                .addPackage(JmsItemReader.class.getPackage())
+                .addAsResource("META-INF/batch-jobs/jms-job.xml");
+    }
+
+    @Resource(lookup = "java:comp/DefaultJMSConnectionFactory")
+    ConnectionFactory factory;
+
+    @Resource(lookup = Resources.TOPIC)
+    Topic topic;
+
+    @EJB
+    ResultCollector collector;
+
+    /**
+     * In this test case we verify that the subscription is really created upon deployment
+     * and thus messages are waiting for the job even before the first run of it.
+     *
+     * The subscription is not deleted even after the application is undeployed, because
+     * the physical topic and its subscription in the message broker still exist,
+     * even after the application scoped managed objects are deleted.
+     *
+     * Following method is used to generate the payload:
+     *
+     * include::#sendMessages[]
+     *
+     * So we send 10 random numbers, and verify that summing integers works exactly the
+     * same way on both ends. Or that the job really picked up all the numbers submitted
+     * for the computation.
+     */
+    @InSequence(1)
+    @Test
+    public void worksAfterDeployment() throws InterruptedException {
+        int sum = sendMessages(10);
+        runJob();
+        assertEquals(10, collector.getLastItemCount());
+        assertEquals(sum, collector.getLastSum());
+        assertEquals(1, collector.getNumberOfJobs());
+    }
+
+    /**
+     *  To verify that the durable subscription really collects messages we do few
+     *  more runs.
+     */
+    @InSequence(2)
+    @Test
+    public void worksInMultipleRuns() throws InterruptedException {
+        int sum = sendMessages(14);
+        runJob();
+        assertEquals(14, collector.getLastItemCount());
+        assertEquals(sum, collector.getLastSum());
+        assertEquals(2, collector.getNumberOfJobs());
+        sum = sendMessages(8); // <1> Sending messages from separate connections makes no difference
+        sum += sendMessages(4);
+        runJob();
+        assertEquals(12, collector.getLastItemCount());
+        assertEquals(sum, collector.getLastSum());
+        assertEquals(3, collector.getNumberOfJobs());
+    }
+
+    private void runJob() throws InterruptedException {
+        JobOperator jobOperator = BatchRuntime.getJobOperator();
+        Long executionId = jobOperator.start("jms-job", new Properties());
+        JobExecution jobExecution = jobOperator.getJobExecution(executionId);
+
+        BatchTestHelper.keepTestAlive(jobExecution);
+    }
+
+    private int sendMessages(int count) {
+        int sum = 0;
+        Random r = new Random();
+        try (JMSContext jms = factory.createContext(Session.AUTO_ACKNOWLEDGE)) {
+            JMSProducer producer = jms.createProducer();
+            for (int i=0; i< count; i++) {
+                int payload = r.nextInt();
+                producer.send(topic, payload);
+                sum += payload;
+            }
+        }
+        return sum;
+    }
+}

--- a/jms/jms-batch/src/test/resources/arquillian.xml
+++ b/jms/jms-batch/src/test/resources/arquillian.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://jboss.org/schema/arquillian" xsi:schemaLocation="http://jboss.org/schema/arquillian
+                         http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <defaultProtocol type="Servlet 3.0"/>
+
+    <container qualifier="test" default="true">
+        <configuration>
+            <property name="jbossHome">${serverRoot:target/wildfly-8.0.0.CR1}</property>
+            <property name="serverConfig">${serverProfile:standalone-full.xml}</property>
+        </configuration>
+    </container>
+
+</arquillian>

--- a/jms/pom.xml
+++ b/jms/pom.xml
@@ -19,6 +19,7 @@
         <module>jms-xa</module>
         <module>send-receive</module>
         <module>temp-destination</module>
+        <module>jms-batch</module>
     </modules>
 
 </project>


### PR DESCRIPTION
I finally had time to document the batch test I've created last weekend. The bad news are it will not pass on WildFly, as it requires credentials to be present in `@JMSConnectionFactoryDefinition`, which seems wrong to me for a application scoped resource.
