### PR TITLE
Clean up Whiteboard Sample

### DIFF
--- a/websocket/whiteboard/src/main/java/org/javaee7/websocket/whiteboard/FigureDecoder.java
+++ b/websocket/whiteboard/src/main/java/org/javaee7/websocket/whiteboard/FigureDecoder.java
@@ -40,6 +40,9 @@
 package org.javaee7.websocket.whiteboard;
 
 import java.io.StringReader;
+import java.lang.invoke.MethodHandles;
+import java.util.logging.Logger;
+
 import javax.json.Json;
 import javax.json.JsonException;
 import javax.json.JsonObject;
@@ -51,9 +54,12 @@ import javax.websocket.EndpointConfig;
  * @author Arun Gupta
  */
 public class FigureDecoder implements Decoder.Text<Figure> {
+
+    private static final Logger LOGGER = Logger.getLogger(MethodHandles.lookup().lookupClass().getName());
+
     @Override
     public Figure decode(String string) throws DecodeException {
-        System.out.println("decoding: " + string);
+        LOGGER.info("decoding: " + string);
         JsonObject jsonObject = Json.createReader(new StringReader(string)).readObject();
         return new Figure(jsonObject);
     }
@@ -71,11 +77,11 @@ public class FigureDecoder implements Decoder.Text<Figure> {
 
     @Override
     public void init(EndpointConfig ec) {
-        System.out.println("init");
+        LOGGER.info("init");
     }
 
     @Override
     public void destroy() {
-        System.out.println("desroy");
+        LOGGER.info("destroy");
     }
 }

--- a/websocket/whiteboard/src/main/java/org/javaee7/websocket/whiteboard/FigureEncoder.java
+++ b/websocket/whiteboard/src/main/java/org/javaee7/websocket/whiteboard/FigureEncoder.java
@@ -39,6 +39,9 @@
  */
 package org.javaee7.websocket.whiteboard;
 
+import java.lang.invoke.MethodHandles;
+import java.util.logging.Logger;
+
 import javax.websocket.EncodeException;
 import javax.websocket.Encoder;
 import javax.websocket.EndpointConfig;
@@ -47,6 +50,9 @@ import javax.websocket.EndpointConfig;
  * @author Arun Gupta
  */
 public class FigureEncoder implements Encoder.Text<Figure> {
+
+    private static final Logger LOGGER = Logger.getLogger(MethodHandles.lookup().lookupClass().getName());
+    
     @Override
     public String encode(Figure figure) throws EncodeException {
         return figure.getJson().toString();
@@ -54,11 +60,11 @@ public class FigureEncoder implements Encoder.Text<Figure> {
 
     @Override
     public void init(EndpointConfig ec) {
-        System.out.println("init");
+        LOGGER.info("init");
     }
 
     @Override
     public void destroy() {
-        System.out.println("desroy");
+        LOGGER.info("destroy");
     }
 }


### PR DESCRIPTION
The whiteboard sample suffers from a potential
`ConcurrentModificationException` because the peers `Set` is iterated
over while other threads can mutate it. Iteration does not block
mutation from other threads. To quote
[Collections.html#synchronizedSet](http://docs.oracle.com/javase/7/docs/api/java/util/Collections.html#synchronizedSet%28java.util.Set%29)

> It is imperative that the user manually synchronize on the returned
> set when iterating over it.
> Failure to follow this advice may result in non-deterministic
> behavior.

In addition the following issues are fixed:
- use proper logging instead of `System.out.println`
- fix typos in log statements
