### PR TITLE
Upgrade to the latest Cassandra Java Driver

### DIFF
--- a/extra/nosql/cassandra/pom.xml
+++ b/extra/nosql/cassandra/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
-            <version>2.0.0-beta2</version>
+            <version>2.0.3</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
The Cassandra Java Driver currently used is an outdated beta.