### PR TITLE
Adding Groovy build plugin in parent pom.xml to allow for importng proje...

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ When developing and runing them from IDE, remember to activate the profile befor
 
 To learn more about Arquillian please refer to the [Arquillian Guides](http://arquillian.org/guides/)
 
+### Importing in Eclipse ###
+
+To import the samples in an Eclipse workspace, please install the [Groovy plugins for your Eclipse version](http://groovy.codehaus.org/Eclipse+Plugin) first, then import the sample projects you want using File>Import>Existing Maven Projects. 
+
 ## How to contribute ##
 
 With your help we can improve this set of samples, learn from each other and grow the community full of passionate people who care about the technology, innovation and code quality. Every contribution matters!

--- a/pom.xml
+++ b/pom.xml
@@ -273,6 +273,12 @@
                 </dependencies>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-eclipse-compiler</artifactId>
+                <version>2.8.0-01</version>
+                <extensions>true</extensions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version>


### PR DESCRIPTION
...cts in Eclipse

Also adding a paragraph to mention that the Groovy tooling for Eclipse should be installed before importing the projects
in the workspace.

See http://groovy.codehaus.org/Groovy-Eclipse+compiler+plugin+for+Maven#Groovy-EclipsecompilerpluginforMaven-Usethegroovy-eclipse-compilermojoforconfiguringsourcefolders for more explanation on why the build plugin was added. Without this plugin configured in the parent pom.xml, Eclipse would not use the src/main/java, src/test/java, etc. folders as source folders for the projects, resulting in many build errors in the workspace. 
