### PR TITLE
#254 Added examples w/ new JMS APIs

### DIFF
--- a/jms/jms-xa/src/main/java/org/javaee7/jms/xa/JMSMailman.java
+++ b/jms/jms-xa/src/main/java/org/javaee7/jms/xa/JMSMailman.java
@@ -6,7 +6,6 @@ import javax.ejb.MessageDriven;
 import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.MessageListener;
-import javax.jms.TextMessage;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -24,8 +23,8 @@ public class JMSMailman implements MessageListener {
     public void onMessage(Message message)
     {
         try {
-            TextMessage tm = (TextMessage) message;
-            logger.info("Message received (async): " + tm.getText());
+            String text = message.getBody(String.class);
+            logger.info("Message received (async): " + text);
             deliveryStats.messageDelivered();
         } catch (JMSException ex) {
             logger.log(Level.SEVERE, null, ex);

--- a/jms/jms-xa/src/main/java/org/javaee7/jms/xa/Mailman.java
+++ b/jms/jms-xa/src/main/java/org/javaee7/jms/xa/Mailman.java
@@ -3,14 +3,10 @@ package org.javaee7.jms.xa;
 import javax.annotation.Resource;
 import javax.ejb.Singleton;
 import javax.inject.Inject;
-import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
+import javax.jms.JMSContext;
 import javax.jms.JMSDestinationDefinition;
-import javax.jms.JMSException;
-import javax.jms.MessageProducer;
 import javax.jms.Queue;
-import javax.jms.Session;
-import javax.jms.TextMessage;
 
 @JMSDestinationDefinition(
     name = Mailman.CLASSIC_QUEUE,
@@ -32,24 +28,8 @@ public class Mailman {
 
     public void sendMessage(String payload)
     {
-        Connection connection = null;
-        try {
-            connection = connectionFactory.createConnection();
-            connection.start();
-            Session session = connection.createSession(false, Session.SESSION_TRANSACTED);
-            MessageProducer messageProducer = session.createProducer(demoQueue);
-            TextMessage textMessage = session.createTextMessage(payload);
-            messageProducer.send(textMessage);
-        } catch (JMSException ex) {
-            ex.printStackTrace();
-        } finally {
-            if (connection != null) {
-                try {
-                    connection.close();
-                } catch (JMSException ex) {
-                    ex.printStackTrace();
-                }
-            }
+        try (JMSContext context = connectionFactory.createContext()) {
+            context.createProducer().send(demoQueue,payload);
         }
     }
 }

--- a/jms/jms-xa/src/test/resources/arquillian.xml
+++ b/jms/jms-xa/src/test/resources/arquillian.xml
@@ -8,4 +8,10 @@
         <property name="deploymentExportPath">target/deployment</property>
     </engine>
 
+    <container qualifier="wildfly">
+        <configuration>
+            <property name="serverConfig">standalone-full.xml</property>
+        </configuration>
+    </container>
+
 </arquillian>

--- a/pom.xml
+++ b/pom.xml
@@ -465,6 +465,7 @@
                         <configuration>
                             <systemPropertyVariables>
                                 <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                                <arquillian.launch>wildfly</arquillian.launch>
                             </systemPropertyVariables>
                             <environmentVariables>
                                 <JBOSS_HOME>${project.build.directory}/wildfly-${org.wildfly}</JBOSS_HOME>
@@ -559,6 +560,9 @@
                             <environmentVariables>
                                 <JBOSS_HOME>${project.build.directory}/wildfly-${org.wildfly}</JBOSS_HOME>
                             </environmentVariables>
+                            <systemPropertyVariables>
+                                <arquillian.launch>wildfly</arquillian.launch>
+                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
I had to add a few extra things:
- Your JMS tests didn't work.  i'll go through and fix them some more, but you need to override the standalone.xml used in server config.  Aslak gave me the tip at Hackergarten
- I can fix the remaining tests, but wanted this in here ASAP.
- You're actually exposing a wildfly/hornetq bug in one of the tests, specifically how it handles transaction propagation.  I wouldn't expect all of these tests to work correctly in glassfish.
