### PR TITLE
Fixed #269.

### DIFF
--- a/batch/chunk-csv-database/src/main/java/org/javaee7/batch/chunk/csv/database/MyItemReader.java
+++ b/batch/chunk-csv-database/src/main/java/org/javaee7/batch/chunk/csv/database/MyItemReader.java
@@ -21,12 +21,7 @@ public class MyItemReader extends AbstractItemReader {
     public void open(Serializable checkpoint) throws Exception {
         reader = new BufferedReader(
                 new InputStreamReader(
-                    this
-                    .getClass()
-                    .getClassLoader()
-                    .getResourceAsStream("/META-INF/mydata.csv")
-                )
-            );
+                        Thread.currentThread().getContextClassLoader().getResourceAsStream("/META-INF/mydata.csv")));
     }
 
     @Override


### PR DESCRIPTION
NPE loading the CSV file from the Glassfish embedded regular classloader. Changed to use the Thread context classloader.
