### PR TITLE
Remove extra params on prePassivate() and postActivate()

### DIFF
--- a/ejb/lifecycle/src/main/java/org/javaee7/ejb/lifecycle/MyStatefulBean.java
+++ b/ejb/lifecycle/src/main/java/org/javaee7/ejb/lifecycle/MyStatefulBean.java
@@ -35,12 +35,12 @@ public class MyStatefulBean {
     }
 
     @PrePassivate
-    private void prePassivate(InvocationContext context) {
+    private void prePassivate() {
         System.out.println("MyStatefulBean.prePassivate");
     }
     
     @PostActivate
-    private void postActivate(InvocationContext context) {
+    private void postActivate() {
         System.out.println("MyStatefulBean.postActivate");
     }
     


### PR DESCRIPTION
According to spec:
http://docs.oracle.com/javaee/7/api/javax/ejb/PostActivate.html
http://docs.oracle.com/javaee/7/api/javax/ejb/PrePassivate.html

> If the method to which this annotation is applied is defined on a target class, it must have the following signature:
> 'void <METHOD>()'

Simply need to remove params on these two methods.
