### PR TITLE
Issue #253 - Fix to make jaxws-endpoint compile against JDK 8

### DIFF
--- a/jaxws/jaxws-endpoint/pom.xml
+++ b/jaxws/jaxws-endpoint/pom.xml
@@ -14,9 +14,9 @@
         <plugins>
             <plugin>
                 <!-- wsgen for wsdl file generation -->
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>org.jvnet.jax-ws-commons</groupId>
                 <artifactId>jaxws-maven-plugin</artifactId>
-                <version>1.11</version>
+                <version>2.3</version>
                 <executions>
                     <execution>
                         <phase>process-classes</phase>


### PR DESCRIPTION
Change to use org.jvnet.jax-ws-commons:jaxws-maven-plugin:2.3 instead of org.codehaus.mojo:jaxws-maven-plugin:1.11
See https://stackoverflow.com/questions/8763595/maven-jaxws-failed-to-execute-wsgen
