### PR TITLE
Fix for #279 - add relativePath to test utils pom so that everything builds together

### DIFF
--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -7,6 +7,7 @@
         <artifactId>javaee7-samples</artifactId>
         <groupId>org.javaee7</groupId>
         <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
@arun-gupta  i tried this out locally after killing my ~/.m2/repository it got to a point w/ wildfly then failed due to not running.  I believe it should be good though.
