### PR TITLE
Adjust polling since spec doesn't guarantee you can poll on a single JobExecution.

### DIFF
--- a/batch/batch-listeners/src/test/java/org/javaee7/batch/batch/listeners/BatchListenersTest.java
+++ b/batch/batch-listeners/src/test/java/org/javaee7/batch/batch/listeners/BatchListenersTest.java
@@ -144,7 +144,7 @@ public class BatchListenersTest {
         Long executionId = jobOperator.start("myJob", new Properties());
         JobExecution jobExecution = jobOperator.getJobExecution(executionId);
 
-        BatchTestHelper.keepTestAlive(jobExecution);
+        jobExecution = BatchTestHelper.keepTestAlive(jobExecution);
 
         List<StepExecution> stepExecutions = jobOperator.getStepExecutions(executionId);
         for (StepExecution stepExecution : stepExecutions) {

--- a/batch/batchlet-simple/src/test/java/org/javaee7/batch/batchlet/simple/MyBatchletTest.java
+++ b/batch/batchlet-simple/src/test/java/org/javaee7/batch/batchlet/simple/MyBatchletTest.java
@@ -73,7 +73,7 @@ public class MyBatchletTest {
         Long executionId = jobOperator.start("myJob", new Properties());
         JobExecution jobExecution = jobOperator.getJobExecution(executionId);
 
-        BatchTestHelper.keepTestAlive(jobExecution);
+        jobExecution = BatchTestHelper.keepTestAlive(jobExecution);
 
         // <1> Job should be completed.
         assertEquals(jobExecution.getBatchStatus(), BatchStatus.COMPLETED);

--- a/batch/chunk-checkpoint/src/test/java/org/javaee7/batch/chunk/checkpoint/BatchChunkCheckpointTest.java
+++ b/batch/chunk-checkpoint/src/test/java/org/javaee7/batch/chunk/checkpoint/BatchChunkCheckpointTest.java
@@ -83,7 +83,7 @@ public class BatchChunkCheckpointTest {
         Long executionId = jobOperator.start("myJob", new Properties());
         JobExecution jobExecution = jobOperator.getJobExecution(executionId);
 
-        BatchTestHelper.keepTestAlive(jobExecution);
+        jobExecution = BatchTestHelper.keepTestAlive(jobExecution);
 
         List<StepExecution> stepExecutions = jobOperator.getStepExecutions(executionId);
         for (StepExecution stepExecution : stepExecutions) {

--- a/batch/chunk-csv-database/src/test/java/org/javaee7/batch/chunk/csv/database/BatchCSVDatabaseTest.java
+++ b/batch/chunk-csv-database/src/test/java/org/javaee7/batch/chunk/csv/database/BatchCSVDatabaseTest.java
@@ -97,7 +97,7 @@ public class BatchCSVDatabaseTest {
         Long executionId = jobOperator.start("myJob", new Properties());
         JobExecution jobExecution = jobOperator.getJobExecution(executionId);
 
-        BatchTestHelper.keepTestAlive(jobExecution);
+        jobExecution = BatchTestHelper.keepTestAlive(jobExecution);
 
         List<StepExecution> stepExecutions = jobOperator.getStepExecutions(executionId);
         for (StepExecution stepExecution : stepExecutions) {

--- a/batch/chunk-exception/src/test/java/org/javaee7/batch/chunk/exception/BatchChunkExceptionTest.java
+++ b/batch/chunk-exception/src/test/java/org/javaee7/batch/chunk/exception/BatchChunkExceptionTest.java
@@ -112,7 +112,7 @@ public class BatchChunkExceptionTest {
         Long executionId = jobOperator.start("myJob", new Properties());
         JobExecution jobExecution = jobOperator.getJobExecution(executionId);
 
-        BatchTestHelper.keepTestAlive(jobExecution);
+        jobExecution = BatchTestHelper.keepTestAlive(jobExecution);
 
         List<StepExecution> stepExecutions = jobOperator.getStepExecutions(executionId);
         for (StepExecution stepExecution : stepExecutions) {

--- a/batch/chunk-mapper/src/test/java/org/javaee7/batch/sample/chunk/mapper/BatchChunkMapperTest.java
+++ b/batch/chunk-mapper/src/test/java/org/javaee7/batch/sample/chunk/mapper/BatchChunkMapperTest.java
@@ -91,7 +91,7 @@ public class BatchChunkMapperTest {
         Long executionId = jobOperator.start("myJob", new Properties());
         JobExecution jobExecution = jobOperator.getJobExecution(executionId);
 
-        BatchTestHelper.keepTestAlive(jobExecution);
+        jobExecution = BatchTestHelper.keepTestAlive(jobExecution);
 
         List<StepExecution> stepExecutions = jobOperator.getStepExecutions(executionId);
         for (StepExecution stepExecution : stepExecutions) {

--- a/batch/chunk-optional-processor/src/test/java/org/javaee7/batch/chunk/optional/processor/BatchChunkOptionalProcessorTest.java
+++ b/batch/chunk-optional-processor/src/test/java/org/javaee7/batch/chunk/optional/processor/BatchChunkOptionalProcessorTest.java
@@ -69,7 +69,7 @@ public class BatchChunkOptionalProcessorTest {
         Long executionId = jobOperator.start("myJob", new Properties());
         JobExecution jobExecution = jobOperator.getJobExecution(executionId);
 
-        BatchTestHelper.keepTestAlive(jobExecution);
+        jobExecution = BatchTestHelper.keepTestAlive(jobExecution);
 
         List<StepExecution> stepExecutions = jobOperator.getStepExecutions(executionId);
         for (StepExecution stepExecution : stepExecutions) {

--- a/batch/chunk-partition/src/test/java/org/javaee7/batch/sample/chunk/partition/BatchChunkPartitionTest.java
+++ b/batch/chunk-partition/src/test/java/org/javaee7/batch/sample/chunk/partition/BatchChunkPartitionTest.java
@@ -86,7 +86,7 @@ public class BatchChunkPartitionTest {
         Long executionId = jobOperator.start("myJob", new Properties());
         JobExecution jobExecution = jobOperator.getJobExecution(executionId);
 
-        BatchTestHelper.keepTestAlive(jobExecution);
+        jobExecution = BatchTestHelper.keepTestAlive(jobExecution);
 
         List<StepExecution> stepExecutions = jobOperator.getStepExecutions(executionId);
         for (StepExecution stepExecution : stepExecutions) {

--- a/batch/chunk-simple-nobeans/src/test/java/org/javaee7/batch/samples/chunk/simple/nobeans/BatchChunkSimpleNoBeansTest.java
+++ b/batch/chunk-simple-nobeans/src/test/java/org/javaee7/batch/samples/chunk/simple/nobeans/BatchChunkSimpleNoBeansTest.java
@@ -67,7 +67,7 @@ public class BatchChunkSimpleNoBeansTest {
         Long executionId = jobOperator.start("myJob", new Properties());
         JobExecution jobExecution = jobOperator.getJobExecution(executionId);
 
-        BatchTestHelper.keepTestAlive(jobExecution);
+        jobExecution = BatchTestHelper.keepTestAlive(jobExecution);
 
         List<StepExecution> stepExecutions = jobOperator.getStepExecutions(executionId);
         for (StepExecution stepExecution : stepExecutions) {

--- a/batch/chunk-simple/src/test/java/org/javaee7/batch/chunk/simple/ChunkSimpleTest.java
+++ b/batch/chunk-simple/src/test/java/org/javaee7/batch/chunk/simple/ChunkSimpleTest.java
@@ -68,7 +68,7 @@ public class ChunkSimpleTest {
         Long executionId = jobOperator.start("myJob", new Properties());
         JobExecution jobExecution = jobOperator.getJobExecution(executionId);
 
-        BatchTestHelper.keepTestAlive(jobExecution);
+        jobExecution = BatchTestHelper.keepTestAlive(jobExecution);
 
         List<StepExecution> stepExecutions = jobOperator.getStepExecutions(executionId);
         for (StepExecution stepExecution : stepExecutions) {

--- a/batch/decision/src/test/java/org/javaee7/batch/decision/BatchDecisionTest.java
+++ b/batch/decision/src/test/java/org/javaee7/batch/decision/BatchDecisionTest.java
@@ -73,7 +73,7 @@ public class BatchDecisionTest {
         Long executionId = jobOperator.start("myJob", new Properties());
         JobExecution jobExecution = jobOperator.getJobExecution(executionId);
 
-        BatchTestHelper.keepTestAlive(jobExecution);
+        jobExecution = BatchTestHelper.keepTestAlive(jobExecution);
 
         List<StepExecution> stepExecutions = jobOperator.getStepExecutions(executionId);
         List<String> executedSteps = new ArrayList<>();

--- a/batch/flow/src/test/java/org/javaee7/batch/flow/BatchFlowTest.java
+++ b/batch/flow/src/test/java/org/javaee7/batch/flow/BatchFlowTest.java
@@ -69,7 +69,7 @@ public class BatchFlowTest {
         Long executionId = jobOperator.start("myJob", new Properties());
         JobExecution jobExecution = jobOperator.getJobExecution(executionId);
 
-        BatchTestHelper.keepTestAlive(jobExecution);
+        jobExecution = BatchTestHelper.keepTestAlive(jobExecution);
 
         List<StepExecution> stepExecutions = jobOperator.getStepExecutions(executionId);
         List<String> executedSteps = new ArrayList<>();

--- a/batch/multiple-steps/src/test/java/org/javaee7/batch/multiple/steps/BatchMultipleStepsTest.java
+++ b/batch/multiple-steps/src/test/java/org/javaee7/batch/multiple/steps/BatchMultipleStepsTest.java
@@ -67,7 +67,7 @@ public class BatchMultipleStepsTest {
         Long executionId = jobOperator.start("myJob", new Properties());
         JobExecution jobExecution = jobOperator.getJobExecution(executionId);
 
-        BatchTestHelper.keepTestAlive(jobExecution);
+        jobExecution = BatchTestHelper.keepTestAlive(jobExecution);
 
         List<StepExecution> stepExecutions = jobOperator.getStepExecutions(executionId);
         List<String> executedSteps = new ArrayList<>();

--- a/batch/split/src/test/java/org/javaee7/batch/split/BatchSplitTest.java
+++ b/batch/split/src/test/java/org/javaee7/batch/split/BatchSplitTest.java
@@ -71,7 +71,7 @@ public class BatchSplitTest {
         Long executionId = jobOperator.start("myJob", new Properties());
         JobExecution jobExecution = jobOperator.getJobExecution(executionId);
 
-        BatchTestHelper.keepTestAlive(jobExecution);
+        jobExecution = BatchTestHelper.keepTestAlive(jobExecution);
 
         List<StepExecution> stepExecutions = jobOperator.getStepExecutions(executionId);
         List<String> executedSteps = new ArrayList<>();

--- a/util/src/main/java/org/javaee7/util/BatchTestHelper.java
+++ b/util/src/main/java/org/javaee7/util/BatchTestHelper.java
@@ -1,8 +1,10 @@
 package org.javaee7.util;
 
+import javax.batch.runtime.BatchRuntime;
 import javax.batch.runtime.BatchStatus;
 import javax.batch.runtime.JobExecution;
 import javax.batch.runtime.Metric;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -11,31 +13,33 @@ import java.util.Map;
  */
 public final class BatchTestHelper {
     private static final int MAX_TRIES = 10;
-    private static final int THREAD_SLEEP = 100;
+    private static final int THREAD_SLEEP = 1000;
 
     private BatchTestHelper() {
         throw new UnsupportedOperationException();
     }
 
     /**
-     * We need to keep the test running because JobOperator runs the batch job in an asynchronous way, so the
-     * JobExecution can be properly updated with the running job status.
+     * We need to keep the test running because JobOperator runs the batch job in an asynchronous way.
+     * Returns when either the job execution completes or we have polled the maximum number of tries.
      *
      * @param jobExecution
      *         the JobExecution of the job that is being runned on JobOperator.
-     *
+     * @return the most recent JobExecution obtained for this execution
      * @throws InterruptedException thrown by Thread.sleep.
      */
-    public static void keepTestAlive(JobExecution jobExecution) throws InterruptedException {
+    public static JobExecution keepTestAlive(JobExecution jobExecution) throws InterruptedException {
         int maxTries = 0;
         while (!jobExecution.getBatchStatus().equals(BatchStatus.COMPLETED)) {
             if (maxTries < MAX_TRIES) {
                 maxTries++;
                 Thread.sleep(THREAD_SLEEP);
+                jobExecution = BatchRuntime.getJobOperator().getJobExecution(jobExecution.getExecutionId());
             } else {
                 break;
             }
         }
+        return jobExecution;
     }
 
     /**


### PR DESCRIPTION
It is valid per the specification for a **JobExecution** object to contain a snapshot of status and other data.  It is not required to contain a "live" view into the repository.    I know the WebSphere Liberty Profile (beta) batch support uses the snapshot approach, and presumably Spring Batch does at well since they raised the issue against the TCK at one point when it was assuming "live" data.

Updated with an equivalent solution that should work with either approach.
