### PR TITLE
New profile 'wildfly-docker-maven' for testing with rhuss/docker-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -729,7 +729,7 @@
                             <arq.container.wildfly-docker.configuration.password>Admin#70365</arq.container.wildfly-docker.configuration.password>
                             <arq.extension.docker.serverVersion>1.15</arq.extension.docker.serverVersion>
                             <!--<arq.extension.docker.serverUri>http://192.168.59.103:2376</arq.extension.docker.serverUri>-->
-                            <arq.extension.docker.serverUri>http://boot2docker:2376</arq.extension.docker.serverUri>
+                            <arq.extension.docker.serverUri>http://127.0.0.1:2375</arq.extension.docker.serverUri>
                             <arq.extension.docker.dockerContainers>
                                 wildfly-docker:
                                     image: arungupta/javaee7-samples-wildfly

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <java.min.version>1.7</java.min.version>
         <maven.min.version>3.0.0</maven.min.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <org.jboss.arquillian.version>1.1.1.Final</org.jboss.arquillian.version>
+        <org.jboss.arquillian.version>1.1.7.Final</org.jboss.arquillian.version>
         <org.jboss.arquillian.drone.version>1.3.0.Final</org.jboss.arquillian.drone.version>
         <org.jboss.arquillian.selenium.bom.version>2.40.0</org.jboss.arquillian.selenium.bom.version>
         <org.jboss.arquillian.graphene.version>2.0.2.Final</org.jboss.arquillian.graphene.version>
@@ -729,7 +729,7 @@
                             <arq.container.wildfly-docker.configuration.password>Admin#70365</arq.container.wildfly-docker.configuration.password>
                             <arq.extension.docker.serverVersion>1.15</arq.extension.docker.serverVersion>
                             <!--<arq.extension.docker.serverUri>http://192.168.59.103:2376</arq.extension.docker.serverUri>-->
-                            <arq.extension.docker.serverUri>http://127.0.0.1:2375</arq.extension.docker.serverUri>
+                            <arq.extension.docker.serverUri>http://boot2docker:2376</arq.extension.docker.serverUri>
                             <arq.extension.docker.dockerContainers>
                                 wildfly-docker:
                                     image: arungupta/javaee7-samples-wildfly
@@ -747,70 +747,111 @@
             </build>
         </profile>
         <profile>
-            <id>wildfly-docker-arquillian-maven</id>
+            <id>wildfly-docker-maven</id>
             <properties>
-                <browser>chromium-browser</browser>
-                <serverProfile>standalone-full.xml</serverProfile>
-                <serverRoot>${project.build.directory}/wildfly-${org.wildfly}</serverRoot>
+                <docker.api.host>localhost</docker.api.host>
             </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>org.arquillian.cube</groupId>
-                    <artifactId>arquillian-cube-docker</artifactId>
-                    <version>${org.jboss.arquillian.cube.version}</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>io.undertow</groupId>
-                    <artifactId>undertow-websockets-jsr</artifactId>
-                    <version>1.0.0.Beta25</version>
-                    <scope>test</scope>
-                </dependency>
-                <!--                <dependency>
-                    <groupId>org.jboss.resteasy</groupId>
-                    <artifactId>resteasy-client</artifactId>
-                    <version>3.0.5.Final</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.jboss.resteasy</groupId>
-                    <artifactId>resteasy-jaxb-provider</artifactId>
-                    <version>3.0.5.Final</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.jboss.resteasy</groupId>
-                    <artifactId>resteasy-json-p-provider</artifactId>
-                    <version>3.0.5.Final</version>
-                    <scope>test</scope>
-                </dependency>-->
-                <dependency>
-                    <groupId>org.wildfly</groupId>
-                    <artifactId>wildfly-arquillian-container-remote</artifactId>
-                    <version>${org.wildfly}</version>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
             <build>
-                <testResources>
-                    <testResource>
-                        <directory>src/test/resources</directory>
-                        <filtering>true</filtering>
-                    </testResource>
-                </testResources>
                 <plugins>
                     <plugin>
                         <groupId>org.jolokia</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
-                        <version>0.10.4</version>
+                        <version>0.11.3-SNAPSHOT</version>
                         <configuration>
                             <images>
                                 <image>
-                                    <name>arungupta/wildfly-centos</name>
+                                    <name>${project.groupId}/${project.artifactId}</name>
+                                    <alias>wildfly</alias>
+                                    <!-- How to build image with servlet included -->
+                                    <build>
+                                        <!-- Base image (aka "USE") -->
+                                        <from>arungupta/javaee7-samples-wildfly</from>
+                                        <!-- Exposed ports -->
+                                        <ports>
+                                            <port>8080</port>
+                                            <port>9990</port>
+                                        </ports>
+                                        <!-- Describe what to put into the image with an assembly -->
+                                        <assembly>
+                                            <!-- The artefact will be copied there into the image -->
+                                            <basedir>/opt/wildfly/standalone/deployments</basedir>
+                                            <!-- Use the artifact (predefined descriptor) -->
+                                            <descriptorRef>artifact</descriptorRef>
+                                        </assembly>
+                                    </build>
+                                    <!-- How to run it for integration tests or "docker:start" and "docker:stop" -->
+                                    <run>
+                                        <ports>
+                                            <!-- Dynamically let Docker choose ports, store them in ${wildfly.http.port}
+                                                 and ${wildfly.admin.port} -->
+                                            <port>wildfly.http.port:8080</port>
+                                            <port>wildfly.admin.port:9990</port>
+                                        </ports>
+                                        <wait>
+                                            <!-- The plugin waits until this URL is reachable via HTTP ... -->
+                                            <url>http://${docker.api.host}:${wildfly.http.port}</url>
+                                            <!-- ... but at most 10 seconds -->
+                                            <time>10000</time>
+                                        </wait>
+                                    </run>
                                 </image>
                             </images>
                         </configuration>
+                        <executions>
+                            <!-- Hook this plugin into pre- and post-integration tests -->
+                            <execution>
+                                <id>start</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>build</goal>
+                                    <goal>start</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>stop</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
+
+                    <!-- Skip Arquillian Tests -->
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+
+                     <plugin>
+                         <artifactId>maven-failsafe-plugin</artifactId>
+                         <version>2.18.1</version>
+                         <configuration>
+                             <systemPropertyVariables>
+                                 <!-- In our example, since we use the "artifact" assembly descriptor ref, the WAR is
+                                      called like the artifacto ("simple-servlet.war") and hence the webapp context is
+                                      also the same -->
+                                 <test.url>http://${docker.api.host}:${wildfly.http.port}/${project.artifactId}</test.url>
+                             </systemPropertyVariables>
+                         </configuration>
+                         <!--  Boilerplate for enablign the failsafe tests (test classes need to end with "IT") -->
+                         <executions>
+                             <execution>
+                                 <id>integration-test</id>
+                                 <goals>
+                                     <goal>integration-test</goal>
+                                 </goals>
+                             </execution>
+                             <execution>
+                                 <id>verify</id>
+                                 <goals>
+                                     <goal>verify</goal>
+                                 </goals>
+                             </execution>
+                         </executions>
+                     </plugin>
                 </plugins>
             </build>
         </profile>

--- a/servlet/simple-servlet/src/test/java/org/javaee7/servlet/metadata/complete/SimpleServletArquillianTest.java
+++ b/servlet/simple-servlet/src/test/java/org/javaee7/servlet/metadata/complete/SimpleServletArquillianTest.java
@@ -1,29 +1,28 @@
 package org.javaee7.servlet.metadata.complete;
 
-import org.javaee7.servlet.simple.SimpleServlet;
-import com.gargoylesoftware.htmlunit.HttpMethod;
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
-import com.gargoylesoftware.htmlunit.WebRequest;
-import java.io.File;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URL;
+
+import com.gargoylesoftware.htmlunit.*;
+import org.javaee7.servlet.simple.SimpleServlet;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.xml.sax.SAXException;
 
+import static org.junit.Assert.assertEquals;
+
 /**
  * @author Arun Gupta
  */
 @RunWith(Arquillian.class)
-public class SimpleServletTest {
+public class SimpleServletArquillianTest {
 
     @ArquillianResource
     private URL base;
@@ -38,8 +37,11 @@ public class SimpleServletTest {
     }
     
     @Before
-    public void setup() {
+    public void setup() throws MalformedURLException {
         webClient = new WebClient();
+        if (base == null) {
+            base = new URL(System.getProperty("test.url"));
+        }
     }
 
     @Test

--- a/servlet/simple-servlet/src/test/java/org/javaee7/servlet/metadata/complete/SimpleServletArquillianTest.java
+++ b/servlet/simple-servlet/src/test/java/org/javaee7/servlet/metadata/complete/SimpleServletArquillianTest.java
@@ -1,7 +1,6 @@
 package org.javaee7.servlet.metadata.complete;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URL;
 
 import com.gargoylesoftware.htmlunit.*;
@@ -37,11 +36,8 @@ public class SimpleServletArquillianTest {
     }
     
     @Before
-    public void setup() throws MalformedURLException {
+    public void setup() {
         webClient = new WebClient();
-        if (base == null) {
-            base = new URL(System.getProperty("test.url"));
-        }
     }
 
     @Test

--- a/servlet/simple-servlet/src/test/java/org/javaee7/servlet/metadata/complete/SimpleServletPlainIT.java
+++ b/servlet/simple-servlet/src/test/java/org/javaee7/servlet/metadata/complete/SimpleServletPlainIT.java
@@ -1,0 +1,42 @@
+package org.javaee7.servlet.metadata.complete;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import com.gargoylesoftware.htmlunit.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.xml.sax.SAXException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Roland Huss
+ *
+ * Plain Test without any framework dependency accessing the test servlet directly.
+ */
+public class SimpleServletPlainIT {
+
+    private WebClient webClient;
+    private URL base;
+
+    @Before
+    public void setup() throws MalformedURLException {
+        webClient = new WebClient();
+        base = new URL(System.getProperty("test.url"));
+    }
+
+    @Test
+    public void testGet() throws IOException, SAXException {
+        TextPage page = webClient.getPage(base + "/SimpleServlet");
+        assertEquals("my GET", page.getContent());
+    }
+
+    @Test
+    public void testPost() throws IOException, SAXException {
+        WebRequest request = new WebRequest(new URL(base + "/SimpleServlet"), HttpMethod.POST);
+        TextPage page = webClient.getPage(request);
+        assertEquals("my POST", page.getContent());
+    }
+}


### PR DESCRIPTION
This profile demonstrates the usage of [docker-maven-plugin](https://github.com/rhuss/docker-maven-plugin) for starting a Docker container for integration tests (without Arquillian). It has been tested with the example 'simple-servlet', for which the single unit test has be duplicated to work without Arquillian. The profile uses the `maven-failsafe-plugin` (triggered on `*IT.java` classes) and switched off `maven-surefire-plugin` so that the two tests don't interfere.

The image created contains the deployment artifact already which is copied to `/opt/wildfly/standalone/deployments` so no extra deployment step is required.

To test it simply call:

    mvn  -f servlet/simple-servlet/pom.xml -Pwildfly-docker-maven clean install

(assuming your DOCKER_HOST variable is set properly). One can also build the image, start and stop it separately:

    mvn  -f servlet/simple-servlet/pom.xml -Pwildfly-docker-maven package docker:build
    mvn  -f servlet/simple-servlet/pom.xml -Pwildfly-docker-maven docker:start
    mvn  -f servlet/simple-servlet/pom.xml -Pwildfly-docker-maven docker:stop

It use dynamically assigned ports, so multiples test can be run in parallel.

Please note that its quite simplistic and doesn't use all feature of  the plugin. Some comments has been added inline to explain the various pieces, for more information please refer to the [user manual](https://github.com/rhuss/docker-maven-plugin/blob/master/doc/manual.md)

What is not shown is how to push the combined image to a registry with `docker:push`. For this to work, the credentials should be added to `~/.m2/settings.xml` and the name of the image should be adapted accordingly to the docker hub conventions (*user/repo:tag*)