### PR TITLE
Added JASPIC tests that test whether a SAM can forward and include

### DIFF
--- a/jaspic/common/src/main/java/org/javaee7/jaspic/common/ArquillianBase.java
+++ b/jaspic/common/src/main/java/org/javaee7/jaspic/common/ArquillianBase.java
@@ -26,16 +26,22 @@ public class ArquillianBase {
 
     private static final String WEBAPP_SRC = "src/main/webapp";
     private WebClient webClient;
-
+    
     public static Archive<?> defaultArchive() {
-        
-        WebArchive webArchive = 
+        return tryWrapEAR(defaultWebArchive());
+    }
+    
+    public static WebArchive defaultWebArchive() {
+        return 
             create(WebArchive.class, "test.war")
                 .addPackages(true, "org.javaee7.jaspic")
+                .deleteClass(ArquillianBase.class)
                 .addAsWebInfResource(resource("web.xml"))
                 .addAsWebInfResource(resource("jboss-web.xml"))
                 .addAsWebInfResource(resource("glassfish-web.xml"));
-        
+    }
+    
+    public static Archive<?> tryWrapEAR(WebArchive webArchive) {
         if (getBoolean("useEarForJaspic")) {
             return
                 // EAR archive
@@ -48,14 +54,18 @@ public class ArquillianBase {
                     // This is needed to prevent Arquillian generating an illegal application.xml
                     .addAsModule(
                         webArchive
-                    );	
+                    );  
         } else {
             return webArchive;
         }
     }
 
-    private static File resource(String name) {
+    public static File resource(String name) {
         return new File(WEBAPP_SRC + "/WEB-INF", name);
+    }
+    
+    public static File web(String name) {
+        return new File(WEBAPP_SRC, name);
     }
 
     @ArquillianResource

--- a/jaspic/custom-principal/pom.xml
+++ b/jaspic/custom-principal/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.javaee7</groupId>
+        <artifactId>jaspic</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    
+    <artifactId>jaspic-custom-principal</artifactId>
+    <packaging>war</packaging>
+    <name>Java EE 7 Sample: jaspic - custom principal</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.javaee7</groupId>
+            <artifactId>jaspic-common</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/jaspic/custom-principal/src/main/java/org/javaee7/jaspic/customprincipal/sam/MyPrincipal.java
+++ b/jaspic/custom-principal/src/main/java/org/javaee7/jaspic/customprincipal/sam/MyPrincipal.java
@@ -1,0 +1,23 @@
+package org.javaee7.jaspic.customprincipal.sam;
+
+import java.security.Principal;
+
+/**
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+public class MyPrincipal implements Principal {
+
+    private final String name;
+    
+    public MyPrincipal(String name) {
+        this.name = name;
+    }
+    
+    @Override
+    public String getName() {
+        return name;
+    }
+    
+}

--- a/jaspic/custom-principal/src/main/java/org/javaee7/jaspic/customprincipal/sam/SamAutoRegistrationListener.java
+++ b/jaspic/custom-principal/src/main/java/org/javaee7/jaspic/customprincipal/sam/SamAutoRegistrationListener.java
@@ -1,0 +1,22 @@
+package org.javaee7.jaspic.customprincipal.sam;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.annotation.WebListener;
+
+import org.javaee7.jaspic.common.BaseServletContextListener;
+import org.javaee7.jaspic.common.JaspicUtils;
+
+/**
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+@WebListener
+public class SamAutoRegistrationListener extends BaseServletContextListener {
+
+    @Override
+    public void contextInitialized(ServletContextEvent sce) {
+        JaspicUtils.registerSAM(sce.getServletContext(), new TestServerAuthModule());
+    }
+
+}

--- a/jaspic/custom-principal/src/main/java/org/javaee7/jaspic/customprincipal/sam/TestServerAuthModule.java
+++ b/jaspic/custom-principal/src/main/java/org/javaee7/jaspic/customprincipal/sam/TestServerAuthModule.java
@@ -1,0 +1,96 @@
+package org.javaee7.jaspic.customprincipal.sam;
+
+import static javax.security.auth.message.AuthStatus.SEND_SUCCESS;
+import static javax.security.auth.message.AuthStatus.SUCCESS;
+
+import java.io.IOException;
+import java.security.Principal;
+import java.util.Map;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.message.AuthException;
+import javax.security.auth.message.AuthStatus;
+import javax.security.auth.message.MessageInfo;
+import javax.security.auth.message.MessagePolicy;
+import javax.security.auth.message.callback.CallerPrincipalCallback;
+import javax.security.auth.message.callback.GroupPrincipalCallback;
+import javax.security.auth.message.module.ServerAuthModule;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Variant of the SAM used by the basic-authentication test, where the so-called "Principal form" of the
+ * CallerPrincipalCallback is used. Here we pass in a custom Principal instead of a string. 
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+public class TestServerAuthModule implements ServerAuthModule {
+
+    private CallbackHandler handler;
+    private Class<?>[] supportedMessageTypes = new Class[] { HttpServletRequest.class, HttpServletResponse.class };
+
+    @Override
+    public void initialize(MessagePolicy requestPolicy, MessagePolicy responsePolicy, CallbackHandler handler,
+        @SuppressWarnings("rawtypes") Map options) throws AuthException {
+        this.handler = handler;
+    }
+
+    @Override
+    public AuthStatus validateRequest(MessageInfo messageInfo, Subject clientSubject, Subject serviceSubject)
+        throws AuthException {
+
+        HttpServletRequest request = (HttpServletRequest) messageInfo.getRequestMessage();
+
+        Callback[] callbacks;
+
+        if (request.getParameter("doLogin") != null) {
+
+            // For the test perform a login by directly "returning" the details of the authenticated user.
+            // Normally credentials would be checked and the details fetched from some repository
+
+            callbacks = new Callback[] {
+                // The name of the authenticated user *** VIA A CUSTOM PRINCIPAL ***.
+                // This is the main variant of this test vs basic-authentication
+                new CallerPrincipalCallback(clientSubject, new MyPrincipal("test")),
+                // the roles of the authenticated user
+                new GroupPrincipalCallback(clientSubject, new String[] { "architect" })
+            };
+        } else {
+
+            // The JASPIC protocol for "do nothing"
+            callbacks = new Callback[] { new CallerPrincipalCallback(clientSubject, (Principal) null) };
+        }
+
+        try {
+
+            // Communicate the details of the authenticated user to the container. In many
+            // cases the handler will just store the details and the container will actually handle
+            // the login after we return from this method.
+            handler.handle(callbacks);
+
+        } catch (IOException | UnsupportedCallbackException e) {
+            throw (AuthException) new AuthException().initCause(e);
+        }
+
+        return SUCCESS;
+    }
+
+    @Override
+    public Class<?>[] getSupportedMessageTypes() {
+        return supportedMessageTypes;
+    }
+
+    @Override
+    public AuthStatus secureResponse(MessageInfo messageInfo, Subject serviceSubject) throws AuthException {
+        return SEND_SUCCESS;
+    }
+
+    @Override
+    public void cleanSubject(MessageInfo messageInfo, Subject subject) throws AuthException {
+
+    }
+}

--- a/jaspic/custom-principal/src/main/java/org/javaee7/jaspic/customprincipal/servlet/ProtectedServlet.java
+++ b/jaspic/custom-principal/src/main/java/org/javaee7/jaspic/customprincipal/servlet/ProtectedServlet.java
@@ -1,0 +1,45 @@
+package org.javaee7.jaspic.customprincipal.servlet;
+
+import java.io.IOException;
+import java.security.Principal;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.javaee7.jaspic.customprincipal.sam.MyPrincipal;
+
+/**
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+@WebServlet(urlPatterns = "/protected/servlet")
+public class ProtectedServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+
+        response.getWriter().write("This is a protected servlet \n");
+
+        String webName = null;
+        boolean isCustomPrincipal = false;
+        if (request.getUserPrincipal() != null) {
+            Principal principal = request.getUserPrincipal();
+            isCustomPrincipal = principal instanceof MyPrincipal; 
+            webName = request.getUserPrincipal().getName();
+        }
+
+        boolean webHasRole = request.isUserInRole("architect");
+        
+        response.getWriter().write("isCustomPrincipal: " + isCustomPrincipal + "\n");
+        response.getWriter().write("web username: " + webName + "\n");
+        response.getWriter().write("web user has role \"architect\": " + webHasRole + "\n");
+
+    }
+
+}

--- a/jaspic/custom-principal/src/main/java/org/javaee7/jaspic/customprincipal/servlet/PublicServlet.java
+++ b/jaspic/custom-principal/src/main/java/org/javaee7/jaspic/customprincipal/servlet/PublicServlet.java
@@ -1,0 +1,44 @@
+package org.javaee7.jaspic.customprincipal.servlet;
+
+import java.io.IOException;
+import java.security.Principal;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.javaee7.jaspic.customprincipal.sam.MyPrincipal;
+
+/**
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+@WebServlet(urlPatterns = "/public/servlet")
+public class PublicServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+
+        response.getWriter().write("This is a public servlet \n");
+
+        String webName = null;
+        boolean isCustomPrincipal = false;
+        if (request.getUserPrincipal() != null) {
+            Principal principal = request.getUserPrincipal();
+            isCustomPrincipal = principal instanceof MyPrincipal; 
+            webName = principal.getName();
+        }
+        
+        boolean webHasRole = request.isUserInRole("architect");
+
+        response.getWriter().write("isCustomPrincipal: " + isCustomPrincipal + "\n");
+        response.getWriter().write("web username: " + webName + "\n");
+        response.getWriter().write("web user has role \"architect\": " + webHasRole + "\n");
+    }
+
+}

--- a/jaspic/custom-principal/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/jaspic/custom-principal/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE glassfish-web-app PUBLIC "-//GlassFish.org//DTD GlassFish Application Server 3.1 Servlet 3.0//EN" "http://glassfish.org/dtds/glassfish-web-app_3_0-1.dtd">
+<glassfish-web-app>
+
+    <security-role-mapping>
+        <role-name>architect</role-name>
+        <group-name>architect</group-name>
+    </security-role-mapping>
+
+    <parameter-encoding default-charset="UTF-8" />
+
+</glassfish-web-app>

--- a/jaspic/custom-principal/src/main/webapp/WEB-INF/ibm-application-bnd.xml
+++ b/jaspic/custom-principal/src/main/webapp/WEB-INF/ibm-application-bnd.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application-bnd xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-application-bnd_1_2.xsd"
+    xmlns="http://websphere.ibm.com/xml/ns/javaee"
+    version="1.2">
+
+    <security-role name="architect"> 
+        <group name="architect" />
+    </security-role>
+
+</application-bnd>

--- a/jaspic/custom-principal/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/jaspic/custom-principal/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+
+<jboss-web>
+    <security-domain>jaspitest</security-domain>
+</jboss-web>

--- a/jaspic/custom-principal/src/main/webapp/WEB-INF/web.xml
+++ b/jaspic/custom-principal/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+    version="3.0">
+
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>Test</web-resource-name>
+            <url-pattern>/protected/*</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>architect</role-name>
+        </auth-constraint>
+    </security-constraint>
+
+    <security-role>
+        <role-name>architect</role-name>
+    </security-role>
+
+</web-app>

--- a/jaspic/custom-principal/src/test/java/org/javaee7/jaspictest/customprincipal/CustomPrincipalProtectedTest.java
+++ b/jaspic/custom-principal/src/test/java/org/javaee7/jaspictest/customprincipal/CustomPrincipalProtectedTest.java
@@ -1,0 +1,56 @@
+package org.javaee7.jaspictest.customprincipal;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.javaee7.jaspic.common.ArquillianBase;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.xml.sax.SAXException;
+
+/**
+ * This tests that we can login from a protected resource (a resource for which security constraints have been set), then
+ * access it and that for this type of page the custom principal correctly arrives in a Servlet.
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+@RunWith(Arquillian.class)
+public class CustomPrincipalProtectedTest extends ArquillianBase {
+
+    @Deployment(testable = false)
+    public static Archive<?> createDeployment() {
+        return defaultArchive();
+    }
+
+    @Test
+    public void testProtectedPageLoggedin() throws IOException, SAXException {
+
+        String response = getFromServerPath("protected/servlet?doLogin=true");
+
+        // Target resource should be accessible
+        assertTrue(
+            "Authentication seems to have failed, as the expected response from the requested resource is not correct.",
+            response.contains("This is a protected servlet")
+        );
+        
+        // Has to be logged-in with the right principal
+        assertTrue(
+            "Authentication but username is not the expected one 'test'",
+            response.contains("web username: test")
+        );
+        assertTrue(
+            "Authentication succeeded and username is correct, but the expected role 'architect' is not present.",
+            response.contains("web user has role \"architect\": true"));
+        
+        assertTrue(
+            "Authentication succeeded and username and roles are correct, but principal type is not the expected custom type.",
+            response.contains("isCustomPrincipal: true")
+        );
+    }
+
+}

--- a/jaspic/custom-principal/src/test/java/org/javaee7/jaspictest/customprincipal/CustomPrincipalPublicTest.java
+++ b/jaspic/custom-principal/src/test/java/org/javaee7/jaspictest/customprincipal/CustomPrincipalPublicTest.java
@@ -1,0 +1,92 @@
+package org.javaee7.jaspictest.customprincipal;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.javaee7.jaspic.common.ArquillianBase;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.xml.sax.SAXException;
+
+/**
+ * This tests that we can login from a public page (a page for which no security constraints have been set)
+ * and that for this type of page the custom principal correctly arrives in a Servlet.
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+@RunWith(Arquillian.class)
+public class CustomPrincipalPublicTest extends ArquillianBase {
+
+    @Deployment(testable = false)
+    public static Archive<?> createDeployment() {
+        return defaultArchive();
+    }
+
+    @Test
+    public void testPublicPageLoggedin() throws IOException, SAXException {
+
+        // JASPIC has to be able to authenticate a user when accessing a public (non-protected) resource.
+
+        String response = getFromServerPath("public/servlet?doLogin");
+
+        // Has to be logged-in with the right principal
+        assertTrue(
+            "Username is not the expected one 'test'",
+            response.contains("web username: test")
+        );
+        assertTrue(
+            "Username is correct, but the expected role 'architect' is not present.",
+            response.contains("web user has role \"architect\": true"));
+        
+        assertTrue(
+            "Username and roles are correct, but principal type is not the expected custom type.",
+            response.contains("isCustomPrincipal: true")
+        );
+    }
+
+    @Test
+    public void testPublicPageNotRememberLogin() throws IOException, SAXException {
+
+        // -------------------- Request 1 ---------------------------
+
+        String response = getFromServerPath("public/servlet");
+
+        // Not logged-in
+        assertTrue(response.contains("web username: null"));
+        assertTrue(response.contains("web user has role \"architect\": false"));
+
+        // -------------------- Request 2 ---------------------------
+
+        response = getFromServerPath("public/servlet?doLogin");
+
+        // Now has to be logged-in
+        assertTrue(
+            "Username is not the expected one 'test'",
+            response.contains("web username: test")
+        );
+        assertTrue(
+            "Username is correct, but the expected role 'architect' is not present.",
+            response.contains("web user has role \"architect\": true")
+        );
+
+        // -------------------- Request 3 ---------------------------
+
+        response = getFromServerPath("public/servlet");
+
+        // Not logged-in
+        assertTrue(
+            "Should not be authenticated, but username was not null. Did the container remember it from previous request?",
+            response.contains("web username: null")
+        );
+        assertTrue(
+            "Request was not authenticated (username correctly null), but unauthenticated user incorrectly has role 'architect'",
+            response.contains("web user has role \"architect\": false")
+        );
+    }
+
+}

--- a/jaspic/custom-principal/src/test/java/org/javaee7/jaspictest/customprincipal/CustomPrincipalStatelessTest.java
+++ b/jaspic/custom-principal/src/test/java/org/javaee7/jaspictest/customprincipal/CustomPrincipalStatelessTest.java
@@ -1,0 +1,132 @@
+package org.javaee7.jaspictest.customprincipal;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.javaee7.jaspic.common.ArquillianBase;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.xml.sax.SAXException;
+
+/**
+ * Idential test as in basic-authentication, but not performed against a SAM which sets a custom principal.
+ * Therefore tests that for this kind of usage of the PrincipalCallback JASPIC is stateless just as well.
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+@RunWith(Arquillian.class)
+public class CustomPrincipalStatelessTest extends ArquillianBase {
+
+    @Deployment(testable = false)
+    public static Archive<?> createDeployment() {
+        return defaultArchive();
+    }
+
+    /**
+     * Tests that access to a protected page does not depend on the authenticated identity that was established in a previous
+     * request.
+     */
+    @Test
+    public void testProtectedAccessIsStateless() throws IOException, SAXException {
+
+        // -------------------- Request 1 ---------------------------
+
+        // Accessing protected page without login
+        String response = getFromServerPath("protected/servlet");
+
+        // Not logged-in thus should not be accessible.
+        assertFalse(response.contains("This is a protected servlet"));
+
+        // -------------------- Request 2 ---------------------------
+
+        // JASPIC is stateless and login (re-authenticate) has to happen for every request
+        //
+        // If the following fails but "testProtectedPageLoggedin" has succeeded,
+        // the container has probably remembered the "unauthenticated identity", e.g. it has remembered that
+        // we're not authenticated and it will deny further attempts to authenticate. This may happen when
+        // the container does not correctly recognize the JASPIC protocol for "do nothing".
+
+        response = getFromServerPath("protected/servlet?doLogin");
+
+        // Now has to be logged-in so page is accessible
+        assertTrue("Could not access protected page, but should be able to. "
+            + "Did the container remember the previously set 'unauthenticated identity'?",
+            response.contains("This is a protected servlet"));
+
+        // -------------------- Request 3 ---------------------------
+
+        // JASPIC is stateless and login (re-authenticate) has to happen for every request
+        //
+        // In the following method we do a call without logging in after one where we did login.
+        // The container should not remember this login and has to deny access.
+        response = getFromServerPath("protected/servlet");
+
+        // Not logged-in thus should not be accessible.
+        assertFalse("Could access protected page, but should not be able to. "
+            + "Did the container remember the authenticated identity that was set in previous request?",
+            response.contains("This is a protected servlet"));
+    }
+
+    /**
+     * Tests that access to a protected page does not depend on the authenticated identity that was established in a previous
+     * request, but use a different request order than the previous test.
+     */
+    @Test
+    public void testProtectedAccessIsStateless2() throws IOException, SAXException {
+
+        // -------------------- Request 1 ---------------------------
+
+        // Start with doing a login
+        String response = getFromServerPath("protected/servlet?doLogin");
+
+        // -------------------- Request 2 ---------------------------
+
+        // JASPIC is stateless and login (re-authenticate) has to happen for every request
+        //
+        // In the following method we do a call without logging in after one where we did login.
+        // The container should not remember this login and has to deny access.
+
+        // Accessing protected page without login
+        response = getFromServerPath("protected/servlet");
+
+        // Not logged-in thus should not be accessible.
+        assertFalse("Could access protected page, but should not be able to. "
+            + "Did the container remember the authenticated identity that was set in previous request?",
+            response.contains("This is a protected servlet"));
+    }
+
+    /**
+     * Tests independently from being able to access a protected resource if any details of a previously established
+     * authenticated identity are remembered
+     */
+    @Test
+    public void testUserIdentityIsStateless() throws IOException, SAXException {
+
+        // -------------------- Request 1 ---------------------------
+
+        // Accessing protected page with login
+        String response = getFromServerPath("protected/servlet?doLogin");
+
+        // -------------------- Request 2 ---------------------------
+
+        // Accessing public page without login
+        response = getFromServerPath("public/servlet");
+
+        // No details should linger around
+        assertFalse("User principal was 'test', but it should be null here. "
+            + "The container seemed to have remembered it from the previous request.",
+            response.contains("web username: test"));
+        assertTrue("User principal was not null, but it should be null here. ",
+            response.contains("web username: null"));
+        assertTrue("The unauthenticated user has the role 'architect', which should not be the case. "
+            + "The container seemed to have remembered it from the previous request.",
+            response.contains("web user has role \"architect\": false"));
+    }
+
+}

--- a/jaspic/dispatching-jsf-cdi/pom.xml
+++ b/jaspic/dispatching-jsf-cdi/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.javaee7</groupId>
+        <artifactId>jaspic</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    
+    <groupId>org.javaee7</groupId>
+    <artifactId>jaspic-dispatching-jsf-cdi</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>war</packaging>
+    <name>Java EE 7 Sample: jaspic - dispatching JSF CDI</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.javaee7</groupId>
+            <artifactId>jaspic-common</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/jaspic/dispatching-jsf-cdi/src/main/java/org/javaee7/jaspic/dispatching/bean/MyBean.java
+++ b/jaspic/dispatching-jsf-cdi/src/main/java/org/javaee7/jaspic/dispatching/bean/MyBean.java
@@ -1,0 +1,14 @@
+package org.javaee7.jaspic.dispatching.bean;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Named;
+
+@Named
+@RequestScoped
+public class MyBean {
+
+    public String getText() {
+        return "Called from CDI";
+    }
+    
+}

--- a/jaspic/dispatching-jsf-cdi/src/main/java/org/javaee7/jaspic/dispatching/sam/SamAutoRegistrationListener.java
+++ b/jaspic/dispatching-jsf-cdi/src/main/java/org/javaee7/jaspic/dispatching/sam/SamAutoRegistrationListener.java
@@ -1,0 +1,22 @@
+package org.javaee7.jaspic.dispatching.sam;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.annotation.WebListener;
+
+import org.javaee7.jaspic.common.BaseServletContextListener;
+import org.javaee7.jaspic.common.JaspicUtils;
+
+/**
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+@WebListener
+public class SamAutoRegistrationListener extends BaseServletContextListener {
+
+    @Override
+    public void contextInitialized(ServletContextEvent sce) {
+        JaspicUtils.registerSAM(sce.getServletContext(), new TestServerAuthModule());
+    }
+
+}

--- a/jaspic/dispatching-jsf-cdi/src/main/java/org/javaee7/jaspic/dispatching/sam/TestServerAuthModule.java
+++ b/jaspic/dispatching-jsf-cdi/src/main/java/org/javaee7/jaspic/dispatching/sam/TestServerAuthModule.java
@@ -1,0 +1,103 @@
+package org.javaee7.jaspic.dispatching.sam;
+
+import static javax.security.auth.message.AuthStatus.SEND_CONTINUE;
+import static javax.security.auth.message.AuthStatus.SEND_SUCCESS;
+import static javax.security.auth.message.AuthStatus.SUCCESS;
+
+import java.io.IOException;
+import java.security.Principal;
+import java.util.Map;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.message.AuthException;
+import javax.security.auth.message.AuthStatus;
+import javax.security.auth.message.MessageInfo;
+import javax.security.auth.message.MessagePolicy;
+import javax.security.auth.message.callback.CallerPrincipalCallback;
+import javax.security.auth.message.module.ServerAuthModule;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+public class TestServerAuthModule implements ServerAuthModule {
+
+    private CallbackHandler handler;
+    private Class<?>[] supportedMessageTypes = new Class[] { HttpServletRequest.class, HttpServletResponse.class };
+
+    @Override
+    public void initialize(MessagePolicy requestPolicy, MessagePolicy responsePolicy, CallbackHandler handler,
+        @SuppressWarnings("rawtypes") Map options) throws AuthException {
+        this.handler = handler;
+    }
+
+    @Override
+    public AuthStatus validateRequest(MessageInfo messageInfo, Subject clientSubject, Subject serviceSubject) throws AuthException {
+        
+        try {
+            HttpServletRequest request = (HttpServletRequest) messageInfo.getRequestMessage();
+            HttpServletResponse response = (HttpServletResponse) messageInfo.getResponseMessage();
+
+            if ("include".equals(request.getParameter("dispatch"))) {
+                
+                String target = "/includedServlet";
+                if ("jsf".equals(request.getParameter("tech"))) {
+                    target = "/include.jsf";
+                } else  if ("jsfcdi".equals(request.getParameter("tech"))) {
+                    target = "/include-cdi.jsf";
+                }
+                
+                request.getRequestDispatcher(target)
+                       .include(request, response);
+
+                // "Do nothing", required protocol when returning SUCCESS
+                handler.handle(new Callback[] { new CallerPrincipalCallback(clientSubject, (Principal) null) });
+
+                // When using includes, the response stays open and the main
+                // resource can also
+                // write to the response
+                return SUCCESS;
+
+            } else {
+                
+                String target = "/forwardedServlet";
+                if ("jsf".equals(request.getParameter("tech"))) {
+                    target = "/forward.jsf";
+                } else  if ("jsfcdi".equals(request.getParameter("tech"))) {
+                    target = "/forward-cdi.jsf";
+                }
+                
+                request.getRequestDispatcher(target)
+                       .forward(request, response);
+
+                // MUST NOT invoke the resource, so CAN NOT return SUCCESS here.
+                return SEND_CONTINUE;
+            }
+            
+        } catch (IOException | ServletException | UnsupportedCallbackException e) {
+            throw (AuthException) new AuthException().initCause(e);
+        }
+    }
+
+    @Override
+    public Class<?>[] getSupportedMessageTypes() {
+        return supportedMessageTypes;
+    }
+
+    @Override
+    public AuthStatus secureResponse(MessageInfo messageInfo, Subject serviceSubject) throws AuthException {
+        return SEND_SUCCESS;
+    }
+
+    @Override
+    public void cleanSubject(MessageInfo messageInfo, Subject subject) throws AuthException {
+
+    }
+}

--- a/jaspic/dispatching-jsf-cdi/src/main/java/org/javaee7/jaspic/dispatching/servlet/ForwardedServlet.java
+++ b/jaspic/dispatching-jsf-cdi/src/main/java/org/javaee7/jaspic/dispatching/servlet/ForwardedServlet.java
@@ -1,0 +1,32 @@
+package org.javaee7.jaspic.dispatching.servlet;
+
+import java.io.IOException;
+
+import javax.inject.Inject;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.javaee7.jaspic.dispatching.bean.MyBean;
+
+/**
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+@WebServlet(urlPatterns = "/forwardedServlet")
+public class ForwardedServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+    
+    @Inject
+    private MyBean myBean;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        response.getWriter().write("response from forwardedServlet - " + myBean.getText());
+    }
+
+}

--- a/jaspic/dispatching-jsf-cdi/src/main/java/org/javaee7/jaspic/dispatching/servlet/IncludedServlet.java
+++ b/jaspic/dispatching-jsf-cdi/src/main/java/org/javaee7/jaspic/dispatching/servlet/IncludedServlet.java
@@ -1,0 +1,32 @@
+package org.javaee7.jaspic.dispatching.servlet;
+
+import java.io.IOException;
+
+import javax.inject.Inject;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.javaee7.jaspic.dispatching.bean.MyBean;
+
+/**
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+@WebServlet(urlPatterns = "/includedServlet")
+public class IncludedServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+    
+    @Inject
+    private MyBean myBean;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        response.getWriter().write("response from includedServlet - " + myBean.getText());
+    }
+
+}

--- a/jaspic/dispatching-jsf-cdi/src/main/java/org/javaee7/jaspic/dispatching/servlet/ProtectedServlet.java
+++ b/jaspic/dispatching-jsf-cdi/src/main/java/org/javaee7/jaspic/dispatching/servlet/ProtectedServlet.java
@@ -1,0 +1,25 @@
+package org.javaee7.jaspic.dispatching.servlet;
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+@WebServlet(urlPatterns = "/protected/servlet")
+public class ProtectedServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        response.getWriter().write("Resource invoked\n");
+    }
+
+}

--- a/jaspic/dispatching-jsf-cdi/src/main/java/org/javaee7/jaspic/dispatching/servlet/PublicServlet.java
+++ b/jaspic/dispatching-jsf-cdi/src/main/java/org/javaee7/jaspic/dispatching/servlet/PublicServlet.java
@@ -1,0 +1,25 @@
+package org.javaee7.jaspic.dispatching.servlet;
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+@WebServlet(urlPatterns = "/public/servlet")
+public class PublicServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        response.getWriter().write("Resource invoked\n");
+    }
+
+}

--- a/jaspic/dispatching-jsf-cdi/src/main/webapp/WEB-INF/faces-config.xml
+++ b/jaspic/dispatching-jsf-cdi/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<faces-config version="2.0" xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-facesconfig_2_0.xsd">
+</faces-config>

--- a/jaspic/dispatching-jsf-cdi/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/jaspic/dispatching-jsf-cdi/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE glassfish-web-app PUBLIC "-//GlassFish.org//DTD GlassFish Application Server 3.1 Servlet 3.0//EN" "http://glassfish.org/dtds/glassfish-web-app_3_0-1.dtd">
+<glassfish-web-app>
+
+    <security-role-mapping>
+        <role-name>architect</role-name>
+        <group-name>architect</group-name>
+    </security-role-mapping>
+
+    <parameter-encoding default-charset="UTF-8" />
+
+</glassfish-web-app>

--- a/jaspic/dispatching-jsf-cdi/src/main/webapp/WEB-INF/ibm-application-bnd.xml
+++ b/jaspic/dispatching-jsf-cdi/src/main/webapp/WEB-INF/ibm-application-bnd.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application-bnd xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-application-bnd_1_2.xsd"
+    xmlns="http://websphere.ibm.com/xml/ns/javaee"
+    version="1.2">
+
+    <security-role name="architect"> 
+        <group name="architect" />
+    </security-role>
+
+</application-bnd>

--- a/jaspic/dispatching-jsf-cdi/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/jaspic/dispatching-jsf-cdi/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+
+<jboss-web>
+    <security-domain>jaspitest</security-domain>
+</jboss-web>

--- a/jaspic/dispatching-jsf-cdi/src/main/webapp/WEB-INF/web.xml
+++ b/jaspic/dispatching-jsf-cdi/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+    version="3.0">
+
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>Test</web-resource-name>
+            <url-pattern>/protected/*</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>architect</role-name>
+        </auth-constraint>
+    </security-constraint>
+
+    <security-role>
+        <role-name>architect</role-name>
+    </security-role>
+
+</web-app>

--- a/jaspic/dispatching-jsf-cdi/src/main/webapp/forward-cdi.xhtml
+++ b/jaspic/dispatching-jsf-cdi/src/main/webapp/forward-cdi.xhtml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+	xmlns:h="http://xmlns.jcp.org/jsf/html">
+	<h:head>
+		<title>Forward with CDI</title>
+	</h:head>
+	<h:body>
+        response from JSF forward - #{myBean.text}
+    </h:body>
+</html>

--- a/jaspic/dispatching-jsf-cdi/src/main/webapp/forward.xhtml
+++ b/jaspic/dispatching-jsf-cdi/src/main/webapp/forward.xhtml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+	xmlns:h="http://xmlns.jcp.org/jsf/html">
+	<h:head>
+		<title>Forward</title>
+	</h:head>
+	<h:body>
+        response from JSF forward
+    </h:body>
+</html>

--- a/jaspic/dispatching-jsf-cdi/src/main/webapp/include-cdi.xhtml
+++ b/jaspic/dispatching-jsf-cdi/src/main/webapp/include-cdi.xhtml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+	xmlns:h="http://xmlns.jcp.org/jsf/html">
+	<h:head>
+		<title>Include with CDI</title>
+	</h:head>
+	<h:body>
+        response from JSF include - #{myBean.text}
+    </h:body>
+</html>

--- a/jaspic/dispatching-jsf-cdi/src/main/webapp/include.xhtml
+++ b/jaspic/dispatching-jsf-cdi/src/main/webapp/include.xhtml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+	xmlns:h="http://xmlns.jcp.org/jsf/html">
+	<h:head>
+		<title>Include</title>
+	</h:head>
+	<h:body>
+        response from JSF include
+    </h:body>
+</html>

--- a/jaspic/dispatching-jsf-cdi/src/test/java/org/javaee7/jaspictest/dispatching/CDIForwardTest.java
+++ b/jaspic/dispatching-jsf-cdi/src/test/java/org/javaee7/jaspictest/dispatching/CDIForwardTest.java
@@ -1,0 +1,52 @@
+package org.javaee7.jaspictest.dispatching;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.javaee7.jaspic.common.ArquillianBase;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.xml.sax.SAXException;
+
+/**
+ * The basic forward test tests that a SAM is able to forward to a simple Servlet.
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+@RunWith(Arquillian.class)
+public class CDIForwardTest extends ArquillianBase {
+
+    @Deployment(testable = false)
+    public static Archive<?> createDeployment() {
+        return tryWrapEAR(
+            defaultWebArchive()
+                .addAsWebInfResource(resource("beans.xml"))
+        );
+    }
+
+    @Test
+    public void testCDIForwardViaPublicResource() throws IOException, SAXException {
+
+        String response = getFromServerPath("public/servlet");
+        assertTrue(
+            "Response did not contain output from public Servlet with CDI that SAM forwarded to.", 
+            response.contains("response from forwardedServlet - Called from CDI")
+        );
+    }
+    
+    @Test
+    public void testCDIForwardViaProtectedResource() throws IOException, SAXException {
+
+        String response = getFromServerPath("protected/servlet");
+        assertTrue(
+            "Response did not contain output from protected Servlet with CDI that SAM forwarded to.", 
+            response.contains("response from forwardedServlet - Called from CDI")
+        );
+    }
+
+}

--- a/jaspic/dispatching-jsf-cdi/src/test/java/org/javaee7/jaspictest/dispatching/CDIIncludeTest.java
+++ b/jaspic/dispatching-jsf-cdi/src/test/java/org/javaee7/jaspictest/dispatching/CDIIncludeTest.java
@@ -1,0 +1,50 @@
+package org.javaee7.jaspictest.dispatching;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.javaee7.jaspic.common.ArquillianBase;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.xml.sax.SAXException;
+
+/**
+ * The basic forward test tests that a SAM is able to forward to a simple Servlet.
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+@RunWith(Arquillian.class)
+public class CDIIncludeTest extends ArquillianBase {
+
+    @Deployment(testable = false)
+    public static Archive<?> createDeployment() {
+        return defaultArchive();
+    }
+
+    @Test
+    public void testCDIIncludeViaPublicResource() throws IOException, SAXException {
+
+        String response = getFromServerPath("public/servlet?dispatch=include");
+        
+        assertTrue(
+            "Response did not contain output from public Servlet with CDI that SAM included to.", 
+            response.contains("response from includedServlet - Called from CDI")
+        );
+        
+        assertTrue(
+            "Response did not contain output from target Servlet after included one.", 
+            response.contains("Resource invoked")
+        );
+        
+        assertTrue(
+            "Output from included Servlet with CDI and target Servlet in wrong order.",
+            response.indexOf("response from includedServlet - Called from CDI") < response.indexOf("Resource invoked")
+        );
+    }
+
+}

--- a/jaspic/dispatching-jsf-cdi/src/test/java/org/javaee7/jaspictest/dispatching/JSFCDIForwardTest.java
+++ b/jaspic/dispatching-jsf-cdi/src/test/java/org/javaee7/jaspictest/dispatching/JSFCDIForwardTest.java
@@ -1,0 +1,55 @@
+package org.javaee7.jaspictest.dispatching;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.javaee7.jaspic.common.ArquillianBase;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.xml.sax.SAXException;
+
+/**
+ * The JSF with CDI forward test tests that a SAM is able to forward to a JSF view
+ * that uses a CDI backing bean.
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+@RunWith(Arquillian.class)
+public class JSFCDIForwardTest extends ArquillianBase {
+
+    @Deployment(testable = false)
+    public static Archive<?> createDeployment() {
+        return tryWrapEAR(
+            defaultWebArchive()
+                .addAsWebInfResource(resource("beans.xml"))
+                .addAsWebInfResource(resource("faces-config.xml"))
+                .addAsWebResource(web("forward-cdi.xhtml"))
+        );
+    }
+
+    @Test
+    public void testJSFwithCDIForwardViaPublicResource() throws IOException, SAXException {
+
+        String response = getFromServerPath("public/servlet?tech=jsfcdi");
+        assertTrue(
+            "Response did not contain output from JSF view with CDI that SAM forwarded to.", 
+            response.contains("response from JSF forward - Called from CDI")
+        );
+    }
+    
+    @Test
+    public void testJSFwithCDIForwardViaProtectedResource() throws IOException, SAXException {
+
+        String response = getFromServerPath("protected/servlet?tech=jsfcdi");
+        assertTrue(
+            "Response did not contain output from JSF view with CDI that SAM forwarded to.",
+            response.contains("response from JSF forward - Called from CDI")
+        );
+    }
+
+}

--- a/jaspic/dispatching-jsf-cdi/src/test/java/org/javaee7/jaspictest/dispatching/JSFCDIIncludeTest.java
+++ b/jaspic/dispatching-jsf-cdi/src/test/java/org/javaee7/jaspictest/dispatching/JSFCDIIncludeTest.java
@@ -1,0 +1,56 @@
+package org.javaee7.jaspictest.dispatching;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.javaee7.jaspic.common.ArquillianBase;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.xml.sax.SAXException;
+
+/**
+ * The JSF with CDI forward test tests that a SAM is able to include a JSF view
+ * that uses a CDI backing bean.
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+@RunWith(Arquillian.class)
+public class JSFCDIIncludeTest extends ArquillianBase {
+
+    @Deployment(testable = false)
+    public static Archive<?> createDeployment() {
+        return tryWrapEAR(
+                defaultWebArchive()
+                    .addAsWebInfResource(resource("beans.xml"))
+                    .addAsWebInfResource(resource("faces-config.xml"))
+                    .addAsWebResource(web("include-cdi.xhtml"))
+            );
+    }
+
+    @Test
+    public void testJSFwithCDIIncludeViaPublicResource() throws IOException, SAXException {
+
+        String response = getFromServerPath("public/servlet?dispatch=include&tech=jsfcdi");
+        
+        assertTrue(
+            "Response did not contain output from JSF view that SAM included.", 
+            response.contains("response from JSF include - Called from CDI")
+        );
+        
+        assertTrue(
+            "Response did not contain output from target Servlet after included JSF view.", 
+            response.contains("Resource invoked")
+        );
+        
+        assertTrue(
+            "Output from included JSF view and target Servlet in wrong order.",
+            response.indexOf("response from JSF include - Called from CDI") < response.indexOf("Resource invoked")
+        );
+    }
+
+}

--- a/jaspic/dispatching-jsf-cdi/src/test/java/org/javaee7/jaspictest/dispatching/JSFForwardTest.java
+++ b/jaspic/dispatching-jsf-cdi/src/test/java/org/javaee7/jaspictest/dispatching/JSFForwardTest.java
@@ -1,0 +1,53 @@
+package org.javaee7.jaspictest.dispatching;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.javaee7.jaspic.common.ArquillianBase;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.xml.sax.SAXException;
+
+/**
+ * The JSF with CDI forward test tests that a SAM is able to forward to a plain JSF view.
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+@RunWith(Arquillian.class)
+public class JSFForwardTest extends ArquillianBase {
+
+    @Deployment(testable = false)
+    public static Archive<?> createDeployment() {
+        return tryWrapEAR(
+            defaultWebArchive()
+                .addAsWebInfResource(resource("faces-config.xml"))
+                .addAsWebResource(web("forward.xhtml"))
+        );
+    }
+
+    @Test
+    public void testJSFForwardViaPublicResource() throws IOException, SAXException {
+
+        String response = getFromServerPath("public/servlet?tech=jsf");
+        assertTrue(
+            "Response did not contain output from JSF view that SAM forwarded to.", 
+            response.contains("response from JSF forward")
+        );
+    }
+    
+    @Test
+    public void testJSFForwardViaProtectedResource() throws IOException, SAXException {
+
+        String response = getFromServerPath("protected/servlet?tech=jsf");
+        assertTrue(
+            "Response did not contain output from JSF view that SAM forwarded to.",
+            response.contains("response from JSF forward")
+        );
+    }
+
+}

--- a/jaspic/dispatching-jsf-cdi/src/test/java/org/javaee7/jaspictest/dispatching/JSFIncludeTest.java
+++ b/jaspic/dispatching-jsf-cdi/src/test/java/org/javaee7/jaspictest/dispatching/JSFIncludeTest.java
@@ -1,0 +1,54 @@
+package org.javaee7.jaspictest.dispatching;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.javaee7.jaspic.common.ArquillianBase;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.xml.sax.SAXException;
+
+/**
+ * The JSF with CDI forward test tests that a SAM is able to include a plain JSF view.
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+@RunWith(Arquillian.class)
+public class JSFIncludeTest extends ArquillianBase {
+
+    @Deployment(testable = false)
+    public static Archive<?> createDeployment() {
+        return tryWrapEAR(
+                defaultWebArchive()
+                    .addAsWebInfResource(resource("faces-config.xml"))
+                    .addAsWebResource(web("include.xhtml"))
+            );
+    }
+
+    @Test
+    public void testJSFIncludeViaPublicResource() throws IOException, SAXException {
+
+        String response = getFromServerPath("public/servlet?dispatch=include&tech=jsf");
+        
+        assertTrue(
+            "Response did not contain output from JSF view that SAM included.",
+            response.contains("response from JSF include")
+        );
+        
+        assertTrue(
+            "Response did not contain output from target Servlet after included JSF view.", 
+            response.contains("Resource invoked")
+        );
+        
+        assertTrue(
+            "Output from included JSF view and target Servlet in wrong order.",
+            response.indexOf("response from JSF include") < response.indexOf("Resource invoked")
+        );
+    }
+
+}

--- a/jaspic/dispatching/pom.xml
+++ b/jaspic/dispatching/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.javaee7</groupId>
+        <artifactId>jaspic</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <groupId>org.javaee7</groupId>
+    <artifactId>jaspic-dispatching</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>war</packaging>
+    <name>Java EE 7 Sample: jaspic - dispatching</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.javaee7</groupId>
+            <artifactId>jaspic-common</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/jaspic/dispatching/src/main/java/org/javaee7/jaspic/dispatching/sam/SamAutoRegistrationListener.java
+++ b/jaspic/dispatching/src/main/java/org/javaee7/jaspic/dispatching/sam/SamAutoRegistrationListener.java
@@ -1,0 +1,22 @@
+package org.javaee7.jaspic.dispatching.sam;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.annotation.WebListener;
+
+import org.javaee7.jaspic.common.BaseServletContextListener;
+import org.javaee7.jaspic.common.JaspicUtils;
+
+/**
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+@WebListener
+public class SamAutoRegistrationListener extends BaseServletContextListener {
+
+    @Override
+    public void contextInitialized(ServletContextEvent sce) {
+        JaspicUtils.registerSAM(sce.getServletContext(), new TestServerAuthModule());
+    }
+
+}

--- a/jaspic/dispatching/src/main/java/org/javaee7/jaspic/dispatching/sam/TestServerAuthModule.java
+++ b/jaspic/dispatching/src/main/java/org/javaee7/jaspic/dispatching/sam/TestServerAuthModule.java
@@ -1,0 +1,85 @@
+package org.javaee7.jaspic.dispatching.sam;
+
+import static javax.security.auth.message.AuthStatus.SEND_CONTINUE;
+import static javax.security.auth.message.AuthStatus.SEND_SUCCESS;
+import static javax.security.auth.message.AuthStatus.SUCCESS;
+
+import java.io.IOException;
+import java.security.Principal;
+import java.util.Map;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.message.AuthException;
+import javax.security.auth.message.AuthStatus;
+import javax.security.auth.message.MessageInfo;
+import javax.security.auth.message.MessagePolicy;
+import javax.security.auth.message.callback.CallerPrincipalCallback;
+import javax.security.auth.message.module.ServerAuthModule;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+public class TestServerAuthModule implements ServerAuthModule {
+
+    private CallbackHandler handler;
+    private Class<?>[] supportedMessageTypes = new Class[] { HttpServletRequest.class, HttpServletResponse.class };
+
+    @Override
+    public void initialize(MessagePolicy requestPolicy, MessagePolicy responsePolicy, CallbackHandler handler,
+        @SuppressWarnings("rawtypes") Map options) throws AuthException {
+        this.handler = handler;
+    }
+
+    @Override
+    public AuthStatus validateRequest(MessageInfo messageInfo, Subject clientSubject, Subject serviceSubject) throws AuthException {
+        try {
+            HttpServletRequest request = (HttpServletRequest) messageInfo.getRequestMessage();
+            HttpServletResponse response = (HttpServletResponse) messageInfo.getResponseMessage();
+
+            if ("include".equals(request.getParameter("dispatch"))) {
+                request.getRequestDispatcher("/includedServlet")
+                       .include(request, response);
+
+                // "Do nothing", required protocol when returning SUCCESS
+                handler.handle(new Callback[] { new CallerPrincipalCallback(clientSubject, (Principal) null) });
+
+                // When using includes, the response stays open and the main
+                // resource can also write to the response
+                return SUCCESS;
+
+            } else {
+                request.getRequestDispatcher("/forwardedServlet")
+                       .forward(request, response);
+
+                // MUST NOT invoke the resource, so CAN NOT return SUCCESS here.
+                return SEND_CONTINUE;
+            }
+            
+        } catch (IOException | ServletException | UnsupportedCallbackException e) {
+            throw (AuthException) new AuthException().initCause(e);
+        }
+    }
+
+    @Override
+    public Class<?>[] getSupportedMessageTypes() {
+        return supportedMessageTypes;
+    }
+
+    @Override
+    public AuthStatus secureResponse(MessageInfo messageInfo, Subject serviceSubject) throws AuthException {
+        return SEND_SUCCESS;
+    }
+
+    @Override
+    public void cleanSubject(MessageInfo messageInfo, Subject subject) throws AuthException {
+
+    }
+}

--- a/jaspic/dispatching/src/main/java/org/javaee7/jaspic/dispatching/servlet/ForwardedServlet.java
+++ b/jaspic/dispatching/src/main/java/org/javaee7/jaspic/dispatching/servlet/ForwardedServlet.java
@@ -1,0 +1,26 @@
+package org.javaee7.jaspic.dispatching.servlet;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+@WebServlet(urlPatterns = "/forwardedServlet")
+public class ForwardedServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+      response.getWriter().write("response from forwardedServlet");
+    }
+
+}

--- a/jaspic/dispatching/src/main/java/org/javaee7/jaspic/dispatching/servlet/IncludedServlet.java
+++ b/jaspic/dispatching/src/main/java/org/javaee7/jaspic/dispatching/servlet/IncludedServlet.java
@@ -1,0 +1,26 @@
+package org.javaee7.jaspic.dispatching.servlet;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+@WebServlet(urlPatterns = "/includedServlet")
+public class IncludedServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        response.getWriter().write("response from includedServlet");
+    }
+
+}

--- a/jaspic/dispatching/src/main/java/org/javaee7/jaspic/dispatching/servlet/ProtectedServlet.java
+++ b/jaspic/dispatching/src/main/java/org/javaee7/jaspic/dispatching/servlet/ProtectedServlet.java
@@ -1,0 +1,25 @@
+package org.javaee7.jaspic.dispatching.servlet;
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+@WebServlet(urlPatterns = "/protected/servlet")
+public class ProtectedServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        response.getWriter().write("Resource invoked\n");
+    }
+
+}

--- a/jaspic/dispatching/src/main/java/org/javaee7/jaspic/dispatching/servlet/PublicServlet.java
+++ b/jaspic/dispatching/src/main/java/org/javaee7/jaspic/dispatching/servlet/PublicServlet.java
@@ -1,0 +1,25 @@
+package org.javaee7.jaspic.dispatching.servlet;
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+@WebServlet(urlPatterns = "/public/servlet")
+public class PublicServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        response.getWriter().write("Resource invoked\n");
+    }
+
+}

--- a/jaspic/dispatching/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/jaspic/dispatching/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE glassfish-web-app PUBLIC "-//GlassFish.org//DTD GlassFish Application Server 3.1 Servlet 3.0//EN" "http://glassfish.org/dtds/glassfish-web-app_3_0-1.dtd">
+<glassfish-web-app>
+
+    <security-role-mapping>
+        <role-name>architect</role-name>
+        <group-name>architect</group-name>
+    </security-role-mapping>
+
+    <parameter-encoding default-charset="UTF-8" />
+
+</glassfish-web-app>

--- a/jaspic/dispatching/src/main/webapp/WEB-INF/ibm-application-bnd.xml
+++ b/jaspic/dispatching/src/main/webapp/WEB-INF/ibm-application-bnd.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application-bnd xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-application-bnd_1_2.xsd"
+    xmlns="http://websphere.ibm.com/xml/ns/javaee"
+    version="1.2">
+
+    <security-role name="architect"> 
+        <group name="architect" />
+    </security-role>
+
+</application-bnd>

--- a/jaspic/dispatching/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/jaspic/dispatching/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+
+<jboss-web>
+    <security-domain>jaspitest</security-domain>
+</jboss-web>

--- a/jaspic/dispatching/src/main/webapp/WEB-INF/web.xml
+++ b/jaspic/dispatching/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+    version="3.0">
+
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>Test</web-resource-name>
+            <url-pattern>/protected/*</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>architect</role-name>
+        </auth-constraint>
+    </security-constraint>
+
+    <security-role>
+        <role-name>architect</role-name>
+    </security-role>
+
+</web-app>

--- a/jaspic/dispatching/src/test/java/org/javaee7/jaspic/dispatching/BasicForwardTest.java
+++ b/jaspic/dispatching/src/test/java/org/javaee7/jaspic/dispatching/BasicForwardTest.java
@@ -1,0 +1,49 @@
+package org.javaee7.jaspic.dispatching;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.javaee7.jaspic.common.ArquillianBase;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.xml.sax.SAXException;
+
+/**
+ * The basic forward test tests that a SAM is able to forward to a simple Servlet.
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+@RunWith(Arquillian.class)
+public class BasicForwardTest extends ArquillianBase {
+
+    @Deployment(testable = false)
+    public static Archive<?> createDeployment() {
+        return defaultArchive();
+    }
+
+    @Test
+    public void testBasicForwardViaPublicResource() throws IOException, SAXException {
+
+        String response = getFromServerPath("public/servlet");
+        assertTrue(
+            "Response did not contain output from public Servlet that SAM forwarded to.", 
+            response.contains("response from forwardedServlet")
+        );
+    }
+    
+    @Test
+    public void testBasicForwardViaProtectedResource() throws IOException, SAXException {
+
+        String response = getFromServerPath("protected/servlet");
+        assertTrue(
+            "Response did not contain output from protected Servlet that SAM forwarded to.", 
+            response.contains("response from forwardedServlet")
+        );
+    }
+
+}

--- a/jaspic/dispatching/src/test/java/org/javaee7/jaspic/dispatching/BasicIncludeTest.java
+++ b/jaspic/dispatching/src/test/java/org/javaee7/jaspic/dispatching/BasicIncludeTest.java
@@ -1,0 +1,50 @@
+package org.javaee7.jaspic.dispatching;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.javaee7.jaspic.common.ArquillianBase;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.xml.sax.SAXException;
+
+/**
+ * The basic include test tests that a SAM is able to include a simple Servlet.
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+@RunWith(Arquillian.class)
+public class BasicIncludeTest extends ArquillianBase {
+
+    @Deployment(testable = false)
+    public static Archive<?> createDeployment() {
+        return defaultArchive();
+    }
+
+    @Test
+    public void testBasicForwardViaPublicResource() throws IOException, SAXException {
+
+        String response = getFromServerPath("public/servlet?dispatch=include");
+        
+        assertTrue(
+            "Response did not contain output from public Servlet that SAM included to.", 
+            response.contains("response from includedServlet")
+        );
+        
+        assertTrue(
+            "Response did not contain output from target Servlet after included one.", 
+            response.contains("Resource invoked")
+        );
+        
+        assertTrue(
+            "Output from included Servler and target Servlet in wrong order.",
+            response.indexOf("response from includedServlet") < response.indexOf("Resource invoked")
+        );
+    }
+
+}

--- a/jaspic/pom.xml
+++ b/jaspic/pom.xml
@@ -39,6 +39,14 @@
         <!-- Like Servlet filters, a JASPIC SAM for the Servlet Profile can wrap the request and response. This tests that 
             this indeed happens. -->
         <module>wrapping</module>
+        
+         <!-- Like a Servlet a JASPIC SAM for the Servlet Profile can dispatch a request via a forward or include. This tests that 
+            this is indeed possible by using plain Servlets and nothing else. -->
+        <module>dispatching</module>
+        
+        <!-- Like a Servlet a JASPIC SAM for the Servlet Profile can dispatch a request via a forward or include. This tests that 
+            this is indeed possible by using Servlets that are injected with a CDI bean and JSF views. -->
+        <module>dispatching-jsf-cdi</module>
     </modules>
 
     <dependencies>

--- a/jaspic/pom.xml
+++ b/jaspic/pom.xml
@@ -47,6 +47,12 @@
         <!-- Like a Servlet a JASPIC SAM for the Servlet Profile can dispatch a request via a forward or include. This tests that 
             this is indeed possible by using Servlets that are injected with a CDI bean and JSF views. -->
         <module>dispatching-jsf-cdi</module>
+        
+        <!-- Variant of basic-authentication that tests whether a custom principal that's set by a SAM is available
+             in a Servlet via HttpServletRequest#getUserPrincipal
+         -->
+        <module>custom-principal</module>
+        
     </modules>
 
     <dependencies>


### PR DESCRIPTION
several kinds of resources

Tested on JBoss WildFly 8.2, GlassFish 4.1 and (with a small local modification) on WebLogic 12.1.3 (which is Java EE 6).

Several tests fail on each server. I'll be creating issues for them and in case of Mojarra probably look at fixing it myself (if it turns out to be Mojarra issue).