### PR TITLE
Update Liberty Profile with Json Processing Client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -897,6 +897,12 @@
                     <version>2.4</version>
                     <scope>test</scope>
                 </dependency>
+			    <dependency>
+                    <groupId>org.glassfish.jersey.media</groupId>
+                    <artifactId>jersey-media-json-processing</artifactId>
+                    <version>2.4</version>
+                    <scope>test</scope>
+                </dependency>
 			</dependencies>
             
              <build>

--- a/pom.xml
+++ b/pom.xml
@@ -868,42 +868,42 @@
             <id>liberty-managed-arquillian</id>
             
             <dependencies>
-                <dependency>
+		<dependency>
                     <groupId>org.jboss.arquillian.container</groupId>
                     <artifactId>arquillian-wlp-managed-8.5</artifactId>
                     <version>1.0.0.Beta2</version>
-                </dependency>		
-				<dependency>
+		</dependency>		
+		<dependency>
                     <groupId>org.glassfish.tyrus</groupId>
                     <artifactId>tyrus-client</artifactId>
                     <version>1.3</version>
                     <scope>test</scope>
-                </dependency>		
-				<dependency>
+		</dependency>		
+		<dependency>
                     <groupId>org.glassfish</groupId>
                     <artifactId>javax.json</artifactId>
                     <version>1.0.4</version>
                     <scope>test</scope>
-                </dependency>			
-                <dependency>
+		</dependency>			
+		<dependency>
                     <groupId>org.glassfish.tyrus</groupId>
                     <artifactId>tyrus-container-grizzly-client</artifactId>
                     <version>1.3</version>
                     <scope>test</scope>
                 </dependency>
-                <dependency>
+		<dependency>
                     <groupId>org.glassfish.jersey.core</groupId>
                     <artifactId>jersey-client</artifactId>
                     <version>2.4</version>
                     <scope>test</scope>
                 </dependency>
-			    <dependency>
+		<dependency>
                     <groupId>org.glassfish.jersey.media</groupId>
                     <artifactId>jersey-media-json-processing</artifactId>
                     <version>2.4</version>
                     <scope>test</scope>
                 </dependency>
-			</dependencies>
+	     </dependencies>
             
              <build>
                 <plugins>


### PR DESCRIPTION
Update the Liberty Profile in the pom to contain the Jersey Json processing client for the jaxrs-jsonp sample and fix formatting.