### PR TITLE
Added test to see if SAM can set a status code into the response

### DIFF
--- a/jaspic/pom.xml
+++ b/jaspic/pom.xml
@@ -36,12 +36,15 @@
         
          <!-- JASPIC is normally stateless but with a new option introduced in JASPIC 1.1 it can semi-transparently 
              remember an authenticated identity (semi, because the SAM will still be called and has to explicitly
-             indidate it wants to continue this remembered session). This tests that remembering a session indeed works.
+             indicate it wants to continue this remembered session). This tests that remembering a session indeed works.
          -->
         <module>register-session</module>
         
          <!-- Tests behavior of authentication involving asynchronous requests -->
         <module>async-authentication</module>
+        
+        <!-- Tests that a SAM is able to set a status code into the response -->
+        <module>status-codes</module>
         
          <!-- Like a Servlet a JASPIC SAM for the Servlet Profile can dispatch a request via a forward or include. This tests that 
             this is indeed possible by using plain Servlets and nothing else. -->

--- a/jaspic/status-codes/pom.xml
+++ b/jaspic/status-codes/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.javaee7</groupId>
+        <artifactId>jaspic</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>jaspic-status-codes</artifactId>
+    <packaging>war</packaging>
+    
+    <name>Java EE 7 Sample: jaspic - Status codes </name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.javaee7</groupId>
+            <artifactId>jaspic-common</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/jaspic/status-codes/src/main/java/org/javaee7/jaspic/statuscodes/sam/SamAutoRegistrationListener.java
+++ b/jaspic/status-codes/src/main/java/org/javaee7/jaspic/statuscodes/sam/SamAutoRegistrationListener.java
@@ -1,0 +1,22 @@
+package org.javaee7.jaspic.statuscodes.sam;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.annotation.WebListener;
+
+import org.javaee7.jaspic.common.BaseServletContextListener;
+import org.javaee7.jaspic.common.JaspicUtils;
+
+/**
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+@WebListener
+public class SamAutoRegistrationListener extends BaseServletContextListener {
+
+    @Override
+    public void contextInitialized(ServletContextEvent sce) {
+        JaspicUtils.registerSAM(sce.getServletContext(), new TestServerAuthModule());
+    }
+
+}

--- a/jaspic/status-codes/src/main/java/org/javaee7/jaspic/statuscodes/sam/TestServerAuthModule.java
+++ b/jaspic/status-codes/src/main/java/org/javaee7/jaspic/statuscodes/sam/TestServerAuthModule.java
@@ -1,0 +1,62 @@
+package org.javaee7.jaspic.statuscodes.sam;
+
+import static javax.security.auth.message.AuthStatus.SEND_FAILURE;
+import static javax.security.auth.message.AuthStatus.SEND_SUCCESS;
+import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+
+import java.io.IOException;
+import java.util.Map;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.message.AuthException;
+import javax.security.auth.message.AuthStatus;
+import javax.security.auth.message.MessageInfo;
+import javax.security.auth.message.MessagePolicy;
+import javax.security.auth.message.module.ServerAuthModule;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Very basic SAM that just sets an HTTP status code into the response and then returns SEND_FAILURE.
+ * <code>doLogin</code> is present.
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+public class TestServerAuthModule implements ServerAuthModule {
+
+    private Class<?>[] supportedMessageTypes = new Class[] { HttpServletRequest.class, HttpServletResponse.class };
+
+    @Override
+    public void initialize(MessagePolicy requestPolicy, MessagePolicy responsePolicy, CallbackHandler handler, @SuppressWarnings("rawtypes") Map options) throws AuthException {
+    }
+
+    @Override
+    public AuthStatus validateRequest(MessageInfo messageInfo, Subject clientSubject, Subject serviceSubject) throws AuthException {
+
+        HttpServletResponse response  = (HttpServletResponse) messageInfo.getResponseMessage();
+        
+        try {
+            response.sendError(SC_NOT_FOUND);
+            return SEND_FAILURE;
+        } catch (IOException e) {
+            throw (AuthException) new AuthException().initCause(e);
+        }
+    }
+
+    @Override
+    public Class<?>[] getSupportedMessageTypes() {
+        return supportedMessageTypes;
+    }
+
+    @Override
+    public AuthStatus secureResponse(MessageInfo messageInfo, Subject serviceSubject) throws AuthException {
+        return SEND_SUCCESS;
+    }
+
+    @Override
+    public void cleanSubject(MessageInfo messageInfo, Subject subject) throws AuthException {
+
+    }
+}

--- a/jaspic/status-codes/src/main/java/org/javaee7/jaspic/statuscodes/servlet/ProtectedServlet.java
+++ b/jaspic/status-codes/src/main/java/org/javaee7/jaspic/statuscodes/servlet/ProtectedServlet.java
@@ -1,0 +1,26 @@
+package org.javaee7.jaspic.statuscodes.servlet;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+@WebServlet(urlPatterns = "/protected/servlet")
+public class ProtectedServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        response.getWriter().write("This is a protected servlet \n");
+    }
+
+}

--- a/jaspic/status-codes/src/main/java/org/javaee7/jaspic/statuscodes/servlet/PublicServlet.java
+++ b/jaspic/status-codes/src/main/java/org/javaee7/jaspic/statuscodes/servlet/PublicServlet.java
@@ -1,0 +1,26 @@
+package org.javaee7.jaspic.statuscodes.servlet;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+@WebServlet(urlPatterns = "/public/servlet")
+public class PublicServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        response.getWriter().write("This is a public servlet \n");
+    }
+
+}

--- a/jaspic/status-codes/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/jaspic/status-codes/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE glassfish-web-app PUBLIC "-//GlassFish.org//DTD GlassFish Application Server 3.1 Servlet 3.0//EN" "http://glassfish.org/dtds/glassfish-web-app_3_0-1.dtd">
+<glassfish-web-app>
+
+    <security-role-mapping>
+        <role-name>architect</role-name>
+        <group-name>architect</group-name>
+    </security-role-mapping>
+
+    <parameter-encoding default-charset="UTF-8" />
+
+</glassfish-web-app>

--- a/jaspic/status-codes/src/main/webapp/WEB-INF/ibm-application-bnd.xml
+++ b/jaspic/status-codes/src/main/webapp/WEB-INF/ibm-application-bnd.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application-bnd xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-application-bnd_1_2.xsd"
+    xmlns="http://websphere.ibm.com/xml/ns/javaee"
+    version="1.2">
+
+    <security-role name="architect"> 
+        <group name="architect" />
+    </security-role>
+
+</application-bnd>

--- a/jaspic/status-codes/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/jaspic/status-codes/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+
+<jboss-web>
+    <security-domain>jaspitest</security-domain>
+</jboss-web>

--- a/jaspic/status-codes/src/main/webapp/WEB-INF/web.xml
+++ b/jaspic/status-codes/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+    version="3.0">
+
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>Test</web-resource-name>
+            <url-pattern>/protected/*</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>architect</role-name>
+        </auth-constraint>
+    </security-constraint>
+
+    <security-role>
+        <role-name>architect</role-name>
+    </security-role>
+
+</web-app>

--- a/jaspic/status-codes/src/test/java/org/javaee7/jaspic/statuscodes/ProtectedStatusCodesTest.java
+++ b/jaspic/status-codes/src/test/java/org/javaee7/jaspic/statuscodes/ProtectedStatusCodesTest.java
@@ -1,0 +1,43 @@
+package org.javaee7.jaspic.statuscodes;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+
+import org.javaee7.jaspic.common.ArquillianBase;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+/**
+ * This tests that a SAM can set a 404 response code when a protected resource is requested.
+ * Note the resource is not actual invoked, as the SAM returns SEND_FAILURE.
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+@RunWith(Arquillian.class)
+public class ProtectedStatusCodesTest extends ArquillianBase {
+
+    @Deployment(testable = false)
+    public static Archive<?> createDeployment() {
+        return defaultArchive();
+    }
+
+    @Test
+    public void test404inResponse() throws IOException  {
+
+        int code = getWebClient().getPage(getBase() + "protected/servlet")
+                                 .getWebResponse()
+                                 .getStatusCode();
+        
+        assertEquals(
+            "Response should have 404 not found as status code, but did not.", 
+            404, code
+        );
+    }
+
+}

--- a/jaspic/status-codes/src/test/java/org/javaee7/jaspic/statuscodes/PublicStatusCodesTest.java
+++ b/jaspic/status-codes/src/test/java/org/javaee7/jaspic/statuscodes/PublicStatusCodesTest.java
@@ -1,0 +1,43 @@
+package org.javaee7.jaspic.statuscodes;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+
+import org.javaee7.jaspic.common.ArquillianBase;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+/**
+ * This tests that a SAM can set a 404 response code when a public resource is requested.
+ * Note the resource is not actual invoked, as the SAM returns SEND_FAILURE.
+ * 
+ * @author Arjan Tijms
+ * 
+ */
+@RunWith(Arquillian.class)
+public class PublicStatusCodesTest extends ArquillianBase {
+
+    @Deployment(testable = false)
+    public static Archive<?> createDeployment() {
+        return defaultArchive();
+    }
+
+    @Test
+    public void test404inResponse() throws IOException  {
+
+        int code = getWebClient().getPage(getBase() + "public/servlet")
+                                 .getWebResponse()
+                                 .getStatusCode();
+        
+        assertEquals(
+            "Response should have 404 not found as status code, but did not.", 
+            404, code
+        );
+    }
+
+}


### PR DESCRIPTION
Test was tested on WildFly, GlassFish, WebLogic and Liberty.

WildFly fails the test. I'll create an issue on the WildFly/Undertow tracker for that.