### PR TITLE
JPA test for aggregate functions in select clause

### DIFF
--- a/jpa/aggregate-function-in-select/pom.xml
+++ b/jpa/aggregate-function-in-select/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.javaee7</groupId>
+        <artifactId>jpa</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>jpa-aggregate-function-in-select</artifactId>
+    <packaging>war</packaging>
+    
+    <name>Java EE 7 Sample: jpa - aggregate-function-in-select</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+            <version>2.3.3</version>
+        </dependency>
+    </dependencies>
+    
+</project>

--- a/jpa/aggregate-function-in-select/src/main/java/org/javaee7/jpa/aggregate_function_in_select/entity/AggregatedTestEntity.java
+++ b/jpa/aggregate-function-in-select/src/main/java/org/javaee7/jpa/aggregate_function_in_select/entity/AggregatedTestEntity.java
@@ -1,0 +1,25 @@
+package org.javaee7.jpa.aggregate_function_in_select.entity;
+
+/**
+ * A very simple DTO that will be used to aggregate TestEnity to
+ * 
+ * @author Arjan Tijms
+ *
+ */
+public class AggregatedTestEntity {
+	
+	private String values;
+
+	public AggregatedTestEntity(String values) {
+		this.values = values;
+	}
+	
+	public String getValues() {
+		return values;
+	}
+
+	public void setValues(String values) {
+		this.values = values;
+	}
+
+}

--- a/jpa/aggregate-function-in-select/src/main/java/org/javaee7/jpa/aggregate_function_in_select/entity/AggregatedTestEntity.java
+++ b/jpa/aggregate-function-in-select/src/main/java/org/javaee7/jpa/aggregate_function_in_select/entity/AggregatedTestEntity.java
@@ -7,19 +7,19 @@ package org.javaee7.jpa.aggregate_function_in_select.entity;
  *
  */
 public class AggregatedTestEntity {
-	
-	private String values;
 
-	public AggregatedTestEntity(String values) {
-		this.values = values;
-	}
-	
-	public String getValues() {
-		return values;
-	}
+    private String values;
 
-	public void setValues(String values) {
-		this.values = values;
-	}
+    public AggregatedTestEntity(String values) {
+        this.values = values;
+    }
+
+    public String getValues() {
+        return values;
+    }
+
+    public void setValues(String values) {
+        this.values = values;
+    }
 
 }

--- a/jpa/aggregate-function-in-select/src/main/java/org/javaee7/jpa/aggregate_function_in_select/entity/TestEntity.java
+++ b/jpa/aggregate-function-in-select/src/main/java/org/javaee7/jpa/aggregate_function_in_select/entity/TestEntity.java
@@ -1,0 +1,39 @@
+package org.javaee7.jpa.aggregate_function_in_select.entity;
+
+import static javax.persistence.GenerationType.IDENTITY;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+/**
+ * A very simple JPA entity that will be used for testing
+ * 
+ * @author Arjan Tijms
+ *
+ */
+@Entity
+public class TestEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+    private String value;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+}

--- a/jpa/aggregate-function-in-select/src/main/java/org/javaee7/jpa/aggregate_function_in_select/service/TestService.java
+++ b/jpa/aggregate-function-in-select/src/main/java/org/javaee7/jpa/aggregate_function_in_select/service/TestService.java
@@ -35,15 +35,16 @@ public class TestService {
 
     public List<AggregatedTestEntity> getAggregation() {
         return entityManager
-    		.createQuery(
-	        	// Note that GROUP_CONCAT is a DB specific function, in this case for HSQLDB.
-	    		"SELECT new org.javaee7.jpa.aggregate_function_in_select.entity.AggregatedTestEntity("
-	    		+    "FUNCTION('GROUP_CONCAT', _testEntity.value)"
-	    		+ ") "
-	    		+ "FROM "
-	    		+ "    TestEntity _testEntity ", 
-	    		AggregatedTestEntity.class)
-            .getResultList();
+            .createQuery(
+                // Note that GROUP_CONCAT is a DB specific function, in this
+                // case for HSQLDB.
+                "SELECT new org.javaee7.jpa.aggregate_function_in_select.entity.AggregatedTestEntity("
+                +    "FUNCTION('GROUP_CONCAT', _testEntity.value)" 
+                +") " 
+                +"FROM "
+                +    "TestEntity _testEntity ",
+            AggregatedTestEntity.class
+            ).getResultList();
     }
 
 }

--- a/jpa/aggregate-function-in-select/src/main/java/org/javaee7/jpa/aggregate_function_in_select/service/TestService.java
+++ b/jpa/aggregate-function-in-select/src/main/java/org/javaee7/jpa/aggregate_function_in_select/service/TestService.java
@@ -1,0 +1,49 @@
+package org.javaee7.jpa.aggregate_function_in_select.service;
+
+import java.util.List;
+
+import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.javaee7.jpa.aggregate_function_in_select.entity.AggregatedTestEntity;
+import org.javaee7.jpa.aggregate_function_in_select.entity.TestEntity;
+
+/**
+ * This service contains methods to insert two test entities into the database
+ * and to get the aggregation of those.
+ * 
+ * @author Arjan Tijms
+ *
+ */
+@Stateless
+public class TestService {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    public void saveEntities() {
+
+        TestEntity testEntity1 = new TestEntity();
+        testEntity1.setValue("1");
+        TestEntity testEntity2 = new TestEntity();
+        testEntity2.setValue("2");
+
+        entityManager.persist(testEntity1);
+        entityManager.persist(testEntity2);
+    }
+
+    public List<AggregatedTestEntity> getAggregation() {
+        return entityManager
+    		.createQuery(
+	        	// Note that GROUP_CONCAT is a DB specific function, in this case for HSQLDB.
+	    		"SELECT new org.javaee7.jpa.aggregate_function_in_select.entity.AggregatedTestEntity("
+	    		+    "FUNCTION('GROUP_CONCAT', _testEntity.value)"
+	    		+ ") "
+	    		+ "FROM "
+	    		+ "    TestEntity _testEntity ", 
+	    		AggregatedTestEntity.class)
+            .getResultList();
+    }
+
+}

--- a/jpa/aggregate-function-in-select/src/main/resources/META-INF/persistence.xml
+++ b/jpa/aggregate-function-in-select/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence version="2.1" xmlns="http://xmlns.jcp.org/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
+
+    <persistence-unit name="testPU">
+
+        <!-- This data source is defined from within the application via the data-source element in web.xml -->
+        <jta-data-source>java:app/MyApp/MyDS</jta-data-source>
+
+        <properties>
+           <!-- 
+                Very unfortunate workaround to get the data source to work with JPA in WildFly 8+.
+                See https://issues.jboss.org/browse/WFLY-2727  
+            -->
+            <property name="wildfly.jpa.twophasebootstrap" value="false" />
+            <property name="javax.persistence.schema-generation.database.action" value="drop-and-create" />
+        </properties>
+    </persistence-unit>
+    
+</persistence>

--- a/jpa/aggregate-function-in-select/src/main/webapp/WEB-INF/web.xml
+++ b/jpa/aggregate-function-in-select/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd" version="3.1">
+
+    <!-- 
+        This defines the data source that's used by persistence.xml to back to the JPA persistence unit. 
+        The database is embedded within this application (see the pom.xml of this project).
+     -->
+    
+    <data-source>
+        <name>java:app/MyApp/MyDS</name>
+        <!-- org.hsqldb.jdbc.JDBCDataSource is non-XA alternative -->
+        <class-name>org.hsqldb.jdbc.pool.JDBCXADataSource</class-name>
+        <url>jdbc:hsqldb:mem:realtime;user=test;password=testx</url>
+    </data-source>
+
+</web-app>
+

--- a/jpa/aggregate-function-in-select/src/test/java/org/javaee7/jpa/aggregate_function_in_select/AggregateFunctionInSelectTest.java
+++ b/jpa/aggregate-function-in-select/src/test/java/org/javaee7/jpa/aggregate_function_in_select/AggregateFunctionInSelectTest.java
@@ -54,16 +54,16 @@ public class AggregateFunctionInSelectTest {
         List<AggregatedTestEntity> testEntities = testService.getAggregation();
         
         assertTrue(
-    		"All entities should have been aggregated into 1 result row", 
-    		testEntities.size() == 1
-		);
+            "All entities should have been aggregated into 1 result row", 
+            testEntities.size() == 1
+        );
         
         String values = testEntities.get(0).getValues();
         
         assertTrue(
-    		"Aggregation should be 1,2 or 2,1, but was: " + values, 
-    		values.equals("1,2") || values.equals("2,1") // order doesn't matter here
-    	);
+            "Aggregation should be 1,2 or 2,1, but was: " + values, 
+            values.equals("1,2") || values.equals("2,1") // order doesn't matter here
+        );
     }
 
     private static File resource(String name) {

--- a/jpa/aggregate-function-in-select/src/test/java/org/javaee7/jpa/aggregate_function_in_select/AggregateFunctionInSelectTest.java
+++ b/jpa/aggregate-function-in-select/src/test/java/org/javaee7/jpa/aggregate_function_in_select/AggregateFunctionInSelectTest.java
@@ -1,0 +1,72 @@
+package org.javaee7.jpa.aggregate_function_in_select;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.javaee7.jpa.aggregate_function_in_select.entity.AggregatedTestEntity;
+import org.javaee7.jpa.aggregate_function_in_select.service.TestService;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * This tests that an aggregate function can be used in the select clause 
+ * <p>
+ * Currently the JPQL constructor expression is tested for this.
+ * 
+ * @author Arjan Tijms
+ */
+@RunWith(Arquillian.class)
+public class AggregateFunctionInSelectTest {
+
+    private static final String WEBAPP_SRC = "src/main/webapp";
+
+    @Inject
+    private TestService testService;
+
+    @Deployment
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(WebArchive.class)
+            .addPackages(true, AggregateFunctionInSelectTest.class.getPackage())
+            .addAsResource("META-INF/persistence.xml")
+            .addAsWebInfResource(resource("web.xml"))
+            .addAsLibraries(Maven.resolver()
+                .loadPomFromFile("pom.xml")
+                .resolve("org.hsqldb:hsqldb")
+                .withoutTransitivity()
+                .asSingleFile());
+    }
+
+    @Test
+    public void aggregateFunctionInCtorSelectJPQL() throws Exception {
+
+        testService.saveEntities();
+
+        List<AggregatedTestEntity> testEntities = testService.getAggregation();
+        
+        assertTrue(
+    		"All entities should have been aggregated into 1 result row", 
+    		testEntities.size() == 1
+		);
+        
+        String values = testEntities.get(0).getValues();
+        
+        assertTrue(
+    		"Aggregation should be 1,2 or 2,1, but was: " + values, 
+    		values.equals("1,2") || values.equals("2,1") // order doesn't matter here
+    	);
+    }
+
+    private static File resource(String name) {
+        return new File(WEBAPP_SRC + "/WEB-INF", name);
+    }
+}

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -8,13 +8,14 @@
         <version>1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-    <groupId>org.javaee7</groupId>
+    
     <artifactId>jpa</artifactId>
-    <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
+    
     <name>Java EE 7 Sample: jpa</name>
 
     <modules>
+        <module>aggregate-function-in-select</module>
         <module>criteria</module>
         <module>datasourcedefinition</module>
         <module>datasourcedefinition-webxml-pu</module>


### PR DESCRIPTION
Tested on GlassFish, WildFly, Liberty and WebLogic

Fails on GlassFish, WildFly and Liberty for various reasons:

* GlassFish: bug regarding combination between data-source, pu and embedded JDBC
* WildFly: Hibernate bug with the actual aggregate function in select
* Liberty: spec issue with ability to load JDBC driver from WEB-INF/lib

Tested Liberty with alternative version using Liberty proprietary data source and test passed then.
