### PR TITLE
WebLogic 12.1.3 RESTful deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,15 +72,10 @@ There are 5 available container profiles:
     
 * ``weblogic-remote-arquillian``
     
-    This profile requires you to start up a WebLogic server outside of the build. Each sample will then
-    reuse this instance to run the tests. NOTE: this has been tested on WebLogic 12.1.3, which is a Java EE 6 implementation,
-    but it has some Java EE 7 features which can be optionally activated.
+    This profile requires you to start up a WebLogic server outside of the build. Each sample will then reuse this instance to run the tests. NOTE: this has been tested on WebLogic 12.1.3, which is a Java EE 6 implementation, but it has some Java EE 7 features which can be optionally activated.
     
-    This profile requires you to set the location where WebLogic is installed via the ``weblogicRemoteArquillian_wlHome``
-    system property. E.g.
-    
-    ``-DweblogicRemoteArquillian_wlHome=/opt/wls12130``
-    
+    This profile requires reliead upon WebLogic REST management API which you need to explicitly enable as [described in documentation](https://docs.oracle.com/cd/E24329_01/apirefs.1211/e24401/taskhelp/domainconfig/EnableRESTfulManagementServices.html) 
+
     The default username/password are assumed to be "admin" and "admin007" respectively. This can be changed using the
     ``weblogicRemoteArquillian_adminUserName`` and ``weblogicRemoteArquillian_adminPassword`` system properties. E.g.
     

--- a/pom.xml
+++ b/pom.xml
@@ -835,7 +835,7 @@
                 <weblogicRemoteArquillian_adminPassword>admin007</weblogicRemoteArquillian_adminPassword>
         
                 <!-- Default host and port when running WLS locally -->
-                <weblogicRemoteArquillian_adminUrl>t3://localhost:7001</weblogicRemoteArquillian_adminUrl>
+                <weblogicRemoteArquillian_adminUrl>http://localhost:7001</weblogicRemoteArquillian_adminUrl>
         
                 <!-- Default target after having installed developer zip distribution for 
                     WebLogic -->
@@ -845,10 +845,28 @@
             <dependencies>
                 <dependency>
                     <groupId>org.jboss.arquillian.container</groupId>
-                    <artifactId>arquillian-wls-remote-12.1.2</artifactId>
-                    <version>1.0.0.Alpha3</version>
-                    <scope>test</scope>
+                    <artifactId>arquillian-wls-remote-rest</artifactId>
+                    <version>1.0.1.Final</version>
+                    <scope>test</scope>                    
                 </dependency>
+                <dependency>
+                   <groupId>org.glassfish.jersey.core</groupId>
+                   <artifactId>jersey-client</artifactId>
+                   <version>2.15</version>
+                   <scope>test</scope>
+                </dependency>
+		        <dependency>
+		            <groupId>org.glassfish.jersey.media</groupId>
+		            <artifactId>jersey-media-json-processing</artifactId>
+		            <version>2.15</version>
+		            <scope>test</scope>
+		        </dependency>
+		        <dependency>
+		            <groupId>org.glassfish.jersey.media</groupId>
+		            <artifactId>jersey-media-multipart</artifactId>
+		            <version>2.15</version>
+		            <scope>test</scope>                
+		        </dependency>
             </dependencies>
 
             <build>
@@ -858,7 +876,6 @@
                         <configuration>
                             <systemPropertyVariables>
                                 <arquillian.launch>weblogic-remote-arquillian</arquillian.launch>
-                                <wlHome>${weblogicRemoteArquillian_wlHome}</wlHome>
                                 <adminUrl>${weblogicRemoteArquillian_adminUrl}</adminUrl>
                                 <adminUserName>${weblogicRemoteArquillian_adminUserName}</adminUserName>
                                 <adminPassword>${weblogicRemoteArquillian_adminPassword}</adminPassword>


### PR DESCRIPTION
The standard weblogic profile had a problem with remote deployments (as discussed within this #298 thread). This pull-request utilizes the WebLogic RESTful Management Services to do the deployment and thus works with a locally installed WLS as well as the docker image. 
