### PR TITLE
Use the correct instances to destroy CDI beans obtained from Instances.

### DIFF
--- a/cdi/instance-qualifiers/src/test/java/org/javaee7/cdi/instance/AnyGreetingTest.java
+++ b/cdi/instance-qualifiers/src/test/java/org/javaee7/cdi/instance/AnyGreetingTest.java
@@ -49,13 +49,15 @@ public class AnyGreetingTest {
 		assertTrue(instance.isAmbiguous());
 
 		// use Instance<T>#select()
-		Greeting businessBean = instance.select(new AnnotationLiteral<Business>() {}).get();
+		Instance<Greeting> businessInstance = instance.select(new AnnotationLiteral<Business>() {});
+		Greeting businessBean = businessInstance.get();
 		assertThat(businessBean, instanceOf(FormalGreeting.class));
-		instance.destroy(businessBean);
+		businessInstance.destroy(businessBean);
 
-		Greeting defaultBean = instance.select(new AnnotationLiteral<Default>() {}).get();
+		Instance<Greeting> defaultInstance = instance.select(new AnnotationLiteral<Default>() {});
+		Greeting defaultBean = defaultInstance.get();
 		assertThat(defaultBean, instanceOf(SimpleGreeting.class));
-		instance.destroy(defaultBean);
+		defaultInstance.destroy(defaultBean);
 	}
 }
 

--- a/cdi/instance-qualifiers/src/test/java/org/javaee7/cdi/instance/GreetingTest.java
+++ b/cdi/instance-qualifiers/src/test/java/org/javaee7/cdi/instance/GreetingTest.java
@@ -54,9 +54,11 @@ public class GreetingTest {
 		instance.destroy(bean);
 
 		// use Instance<T>#select()
-		Greeting anotherBean = instance.select(new AnnotationLiteral<Default>() {}).get();
+		Instance<Greeting> anotherInstance = instance.select(new AnnotationLiteral<Default>() {
+		});
+		Greeting anotherBean = anotherInstance.get();
 		assertThat(anotherBean, instanceOf(SimpleGreeting.class));
-		instance.destroy(anotherBean);
+		anotherInstance.destroy(anotherBean);
 	}
 }
 


### PR DESCRIPTION
Some CDI tests destroy CDI managed beans retrieved from an Instance at the wrong Instance, so that TomEE/OWB throws a NullPointerException.
This PR fixes this by destroying the beans at the Instances where they were got from.