### PR TITLE
Check that JASPIC authentication failure returns 403 instead of empty

### DIFF
--- a/jaspic/basic-authentication/src/test/java/org/javaee7/jaspic/basicauthentication/BasicAuthenticationProtectedTest.java
+++ b/jaspic/basic-authentication/src/test/java/org/javaee7/jaspic/basicauthentication/BasicAuthenticationProtectedTest.java
@@ -2,6 +2,7 @@ package org.javaee7.jaspic.basicauthentication;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 
@@ -12,6 +13,8 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.xml.sax.SAXException;
+
+import com.gargoylesoftware.htmlunit.WebResponse;
 
 /**
  * This tests that we can login from a protected resource (a resource for which
@@ -31,13 +34,21 @@ public class BasicAuthenticationProtectedTest extends ArquillianBase {
     @Test
     public void testProtectedPageNotLoggedin() throws IOException, SAXException {
 
-        String response = getFromServerPath("protected/servlet");
+        WebResponse response = getResponseFromServerPath("protected/servlet");
 
         // Not logged-in thus should not be accessible.
         assertFalse(
             "Not authenticated, so should not have been able to access protected resource",
-            response.contains("This is a protected servlet")
+            response.getContentAsString().contains("This is a protected servlet")
         );
+        
+        // Not logged-in thus should get a 403
+        assertEquals(
+            "Not authenticated, so should have got a 403 response",
+            403, 
+            response.getStatusCode()
+        );
+
     }
 
     @Test

--- a/jaspic/common/src/main/java/org/javaee7/jaspic/common/ArquillianBase.java
+++ b/jaspic/common/src/main/java/org/javaee7/jaspic/common/ArquillianBase.java
@@ -23,6 +23,7 @@ import org.junit.runner.Description;
 
 import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.WebResponse;
 
 /**
  * 
@@ -35,7 +36,7 @@ public class ArquillianBase {
     private static final Logger logger = Logger.getLogger(ArquillianBase.class.getName());
     
     private WebClient webClient;
-    private String response;
+    private WebResponse response;
     
     @Rule
     public TestWatcher ruleExample = new TestWatcher() {
@@ -51,7 +52,7 @@ public class ArquillianBase {
                 
                 "\nLast response: " +
                 
-                "\n\n"  + formatHTML(response) + "\n\n");
+                "\n\n"  + formatHTML(response.getContentAsString()) + "\n\n");
             
         }
     };
@@ -140,11 +141,22 @@ public class ArquillianBase {
      * @return the raw content as a string as returned by the server
      */
     protected String getFromServerPath(final String path) {
+       return getResponseFromServerPath(path).getContentAsString();
+    }
+    
+    /**
+     * Gets the response from the path that's relative to the base URL on which the Arquillian test
+     * archive is deployed.
+     * 
+     * @param path the path relative to the URL on which the Arquillian test is deployed
+     * @return the response as returned by the server
+     */
+    protected WebResponse getResponseFromServerPath(final String path) {
         response = null;
         for (int i=0; i<=3; i++) {
             try {
-                response = webClient.getPage(base + path).getWebResponse().getContentAsString();
-                if (!response.contains("The response wrapper must wrap the response obtained from getResponse()")) {
+                response = webClient.getPage(base + path).getWebResponse();
+                if (!response.getContentAsString().contains("The response wrapper must wrap the response obtained from getResponse()")) {
                     return response;
                 }
             } catch (FailingHttpStatusCodeException | IOException e) {


### PR DESCRIPTION
200 response

At least Wildfly and Payara return empty 200 reponses when JASPIC returns an unauthenticated user for a protected page.
TomEE returns a 403 response.

I believe that an empty 200 response in case of an authorization failure is not correct behaviour, regardless of the authentication mechanism.