### PR TITLE
JASPIC ServerAuthModule and ServerAuthContext spec compliance fixes

### DIFF
--- a/jaspic/async-authentication/src/main/java/org/javaee7/jaspic/asyncauthentication/sam/SamAutoRegistrationListener.java
+++ b/jaspic/async-authentication/src/main/java/org/javaee7/jaspic/asyncauthentication/sam/SamAutoRegistrationListener.java
@@ -16,7 +16,7 @@ public class SamAutoRegistrationListener extends BaseServletContextListener {
 
     @Override
     public void contextInitialized(ServletContextEvent sce) {
-        JaspicUtils.registerSAM(sce.getServletContext(), new TestServerAuthModule());
+        JaspicUtils.registerSAM(sce.getServletContext(), TestServerAuthModule.class);
     }
 
 }

--- a/jaspic/basic-authentication/src/main/java/org/javaee7/jaspic/basicauthentication/sam/SamAutoRegistrationListener.java
+++ b/jaspic/basic-authentication/src/main/java/org/javaee7/jaspic/basicauthentication/sam/SamAutoRegistrationListener.java
@@ -16,7 +16,7 @@ public class SamAutoRegistrationListener extends BaseServletContextListener {
 
     @Override
     public void contextInitialized(ServletContextEvent sce) {
-        JaspicUtils.registerSAM(sce.getServletContext(), new TestServerAuthModule());
+        JaspicUtils.registerSAM(sce.getServletContext(), TestServerAuthModule.class);
     }
 
 }

--- a/jaspic/basic-authentication/src/main/java/org/javaee7/jaspic/basicauthentication/sam/TestServerAuthModule.java
+++ b/jaspic/basic-authentication/src/main/java/org/javaee7/jaspic/basicauthentication/sam/TestServerAuthModule.java
@@ -2,6 +2,8 @@ package org.javaee7.jaspic.basicauthentication.sam;
 
 import static javax.security.auth.message.AuthStatus.SEND_SUCCESS;
 import static javax.security.auth.message.AuthStatus.SUCCESS;
+import static javax.security.auth.message.AuthStatus.SEND_CONTINUE;
+import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
 import java.io.IOException;
 import java.security.Principal;
@@ -44,6 +46,7 @@ public class TestServerAuthModule implements ServerAuthModule {
         throws AuthException {
 
         HttpServletRequest request = (HttpServletRequest) messageInfo.getRequestMessage();
+        HttpServletResponse response = (HttpServletResponse) messageInfo.getResponseMessage();
 
         Callback[] callbacks;
 
@@ -58,8 +61,12 @@ public class TestServerAuthModule implements ServerAuthModule {
                 // the roles of the authenticated user
                 new GroupPrincipalCallback(clientSubject, new String[] { "architect" })
             };
+        } else if(messageInfo.getMap().get("javax.security.auth.message.MessagePolicy.isMandatory").equals("true")) {
+        	
+        	// Must set error code is authentication is mandatory, but unsuccessful
+        	response.setStatus(SC_UNAUTHORIZED);
+        	return SEND_CONTINUE;
         } else {
-
             // The JASPIC protocol for "do nothing"
             callbacks = new Callback[] { new CallerPrincipalCallback(clientSubject, (Principal) null) };
         }

--- a/jaspic/common/src/main/java/org/javaee7/jaspic/common/JaspicUtils.java
+++ b/jaspic/common/src/main/java/org/javaee7/jaspic/common/JaspicUtils.java
@@ -20,8 +20,8 @@ public final class JaspicUtils {
      * 
      * @param serverAuthModule
      */
-    public static void registerSAM(ServletContext context, ServerAuthModule serverAuthModule) {
-        AuthConfigFactory.getFactory().registerConfigProvider(new TestAuthConfigProvider(serverAuthModule), "HttpServlet",
+    public static void registerSAM(ServletContext context, Class<? extends ServerAuthModule> serverAuthModuleClass) {
+        AuthConfigFactory.getFactory().registerConfigProvider(new TestAuthConfigProvider(serverAuthModuleClass), "HttpServlet",
             getAppContextID(context), "Test authentication config provider");
     }
 

--- a/jaspic/common/src/main/java/org/javaee7/jaspic/common/TestAuthConfigProvider.java
+++ b/jaspic/common/src/main/java/org/javaee7/jaspic/common/TestAuthConfigProvider.java
@@ -22,10 +22,10 @@ public class TestAuthConfigProvider implements AuthConfigProvider {
     private static final String CALLBACK_HANDLER_PROPERTY_NAME = "authconfigprovider.client.callbackhandler";
 
     private Map<String, String> providerProperties;
-    private ServerAuthModule serverAuthModule;
+    private Class<? extends ServerAuthModule> serverAuthModuleClass;
 
-    public TestAuthConfigProvider(ServerAuthModule serverAuthModule) {
-        this.serverAuthModule = serverAuthModule;
+    public TestAuthConfigProvider(Class<? extends ServerAuthModule> serverAuthModuleClass) {
+        this.serverAuthModuleClass = serverAuthModuleClass;
     }
 
     /**
@@ -53,7 +53,7 @@ public class TestAuthConfigProvider implements AuthConfigProvider {
     public ServerAuthConfig getServerAuthConfig(String layer, String appContext, CallbackHandler handler) throws AuthException,
         SecurityException {
         return new TestServerAuthConfig(layer, appContext, handler == null ? createDefaultCallbackHandler() : handler,
-            providerProperties, serverAuthModule);
+            providerProperties, serverAuthModuleClass);
     }
 
     @Override

--- a/jaspic/common/src/main/java/org/javaee7/jaspic/common/TestServerAuthConfig.java
+++ b/jaspic/common/src/main/java/org/javaee7/jaspic/common/TestServerAuthConfig.java
@@ -22,21 +22,21 @@ public class TestServerAuthConfig implements ServerAuthConfig {
     private String appContext;
     private CallbackHandler handler;
     private Map<String, String> providerProperties;
-    private ServerAuthModule serverAuthModule;
+    private Class<? extends ServerAuthModule> serverAuthModuleClass;
 
     public TestServerAuthConfig(String layer, String appContext, CallbackHandler handler,
-        Map<String, String> providerProperties, ServerAuthModule serverAuthModule) {
+        Map<String, String> providerProperties, Class<? extends ServerAuthModule> serverAuthModuleClass) {
         this.layer = layer;
         this.appContext = appContext;
         this.handler = handler;
         this.providerProperties = providerProperties;
-        this.serverAuthModule = serverAuthModule;
+        this.serverAuthModuleClass = serverAuthModuleClass;
     }
 
     @Override
     public ServerAuthContext getAuthContext(String authContextID, Subject serviceSubject,
         @SuppressWarnings("rawtypes") Map properties) throws AuthException {
-        return new TestServerAuthContext(handler, serverAuthModule);
+        return new TestServerAuthContext(handler, serverAuthModuleClass);
     }
 
     // ### The methods below mostly just return what has been passed into the

--- a/jaspic/common/src/main/java/org/javaee7/jaspic/common/TestServerAuthContext.java
+++ b/jaspic/common/src/main/java/org/javaee7/jaspic/common/TestServerAuthContext.java
@@ -1,5 +1,6 @@
 package org.javaee7.jaspic.common;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 
 import javax.security.auth.Subject;
@@ -7,6 +8,9 @@ import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.message.AuthException;
 import javax.security.auth.message.AuthStatus;
 import javax.security.auth.message.MessageInfo;
+import javax.security.auth.message.MessagePolicy;
+import javax.security.auth.message.MessagePolicy.TargetPolicy;
+import javax.security.auth.message.MessagePolicy.ProtectionPolicy;
 import javax.security.auth.message.ServerAuth;
 import javax.security.auth.message.config.ServerAuthContext;
 import javax.security.auth.message.module.ServerAuthModule;
@@ -22,28 +26,60 @@ import javax.security.auth.message.module.ServerAuthModule;
  * @author Arjan Tijms
  */
 public class TestServerAuthContext implements ServerAuthContext {
+	
+	private static TargetPolicy[] targetPolicyArr = { new TargetPolicy(null, new ProtectionPolicy() {
+		public String getID() {
+			return ProtectionPolicy.AUTHENTICATE_SENDER;
+		}
+	}) };
+	
+	private static MessagePolicy mandatoryRequestPolicy = new MessagePolicy(targetPolicyArr, true);
+	private static MessagePolicy optionalRequestPolicy = new MessagePolicy(targetPolicyArr, false);
 
-    private final ServerAuthModule serverAuthModule;
+	private ServerAuthModule mandatoryServerAuthModule; 
+	private ServerAuthModule optionalServerAuthModule; 
+	
+	private ServerAuthModule chooseModule(MessageInfo messageInfo){
+		if("true".equals(messageInfo.getMap().get("javax.security.auth.message.MessagePolicy.isMandatory"))) {
+			return mandatoryServerAuthModule;
+		} else {
+			return optionalServerAuthModule;
+		}
+	}
+	
+    public TestServerAuthContext(CallbackHandler handler, Class<? extends ServerAuthModule> serverAuthModuleClass) throws AuthException {
 
-    public TestServerAuthContext(CallbackHandler handler, ServerAuthModule serverAuthModule) throws AuthException {
-        this.serverAuthModule = serverAuthModule;
-        serverAuthModule.initialize(null, null, handler, Collections.<String, String> emptyMap());
+    	//The spec requires that the mandatory authentication parameter can be accessed from the requestPolicy,
+    	//even though it is not really useful, as the same information is available from the messageInfo map.
+    	//To satisfy this requirement two SAM objects are constructed, and they are initialized with the appropriate requestPolicies. 
+    	
+    	try {
+			mandatoryServerAuthModule = serverAuthModuleClass.getConstructor().newInstance();
+			mandatoryServerAuthModule.initialize(mandatoryRequestPolicy, null, handler, Collections.<String, String> emptyMap());
+	    	
+	    	optionalServerAuthModule = serverAuthModuleClass.getConstructor().newInstance();
+	    	optionalServerAuthModule.initialize(optionalRequestPolicy, null, handler, Collections.<String, String> emptyMap());
+		} catch (InstantiationException | IllegalAccessException | IllegalArgumentException
+				| InvocationTargetException | NoSuchMethodException | SecurityException e) {
+			throw new AuthException();
+		}
+
     }
 
     @Override
     public AuthStatus validateRequest(MessageInfo messageInfo, Subject clientSubject, Subject serviceSubject)
         throws AuthException {
-        return serverAuthModule.validateRequest(messageInfo, clientSubject, serviceSubject);
+        return chooseModule(messageInfo).validateRequest(messageInfo, clientSubject, serviceSubject);
     }
 
     @Override
     public AuthStatus secureResponse(MessageInfo messageInfo, Subject serviceSubject) throws AuthException {
-        return serverAuthModule.secureResponse(messageInfo, serviceSubject);
+        return chooseModule(messageInfo).secureResponse(messageInfo, serviceSubject);
     }
 
     @Override
     public void cleanSubject(MessageInfo messageInfo, Subject subject) throws AuthException {
-        serverAuthModule.cleanSubject(messageInfo, subject);
+    	chooseModule(messageInfo).cleanSubject(messageInfo, subject);
     }
 
 }

--- a/jaspic/custom-principal/src/main/java/org/javaee7/jaspic/customprincipal/sam/SamAutoRegistrationListener.java
+++ b/jaspic/custom-principal/src/main/java/org/javaee7/jaspic/customprincipal/sam/SamAutoRegistrationListener.java
@@ -16,7 +16,7 @@ public class SamAutoRegistrationListener extends BaseServletContextListener {
 
     @Override
     public void contextInitialized(ServletContextEvent sce) {
-        JaspicUtils.registerSAM(sce.getServletContext(), new TestServerAuthModule());
+        JaspicUtils.registerSAM(sce.getServletContext(), TestServerAuthModule.class);
     }
 
 }

--- a/jaspic/custom-principal/src/main/java/org/javaee7/jaspic/customprincipal/sam/TestServerAuthModule.java
+++ b/jaspic/custom-principal/src/main/java/org/javaee7/jaspic/customprincipal/sam/TestServerAuthModule.java
@@ -2,6 +2,8 @@ package org.javaee7.jaspic.customprincipal.sam;
 
 import static javax.security.auth.message.AuthStatus.SEND_SUCCESS;
 import static javax.security.auth.message.AuthStatus.SUCCESS;
+import static javax.security.auth.message.AuthStatus.SEND_CONTINUE;
+import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
 import java.io.IOException;
 import java.security.Principal;
@@ -44,6 +46,7 @@ public class TestServerAuthModule implements ServerAuthModule {
         throws AuthException {
 
         HttpServletRequest request = (HttpServletRequest) messageInfo.getRequestMessage();
+        HttpServletResponse response = (HttpServletResponse) messageInfo.getResponseMessage();
 
         Callback[] callbacks;
 
@@ -59,8 +62,12 @@ public class TestServerAuthModule implements ServerAuthModule {
                 // the roles of the authenticated user
                 new GroupPrincipalCallback(clientSubject, new String[] { "architect" })
             };
+        } else if(messageInfo.getMap().get("javax.security.auth.message.MessagePolicy.isMandatory").equals("true")) {
+        	
+        	// Must set error code if authentication is mandatory, but unsuccessful
+        	response.setStatus(SC_UNAUTHORIZED);
+        	return SEND_CONTINUE;
         } else {
-
             // The JASPIC protocol for "do nothing"
             callbacks = new Callback[] { new CallerPrincipalCallback(clientSubject, (Principal) null) };
         }

--- a/jaspic/dispatching-jsf-cdi/src/main/java/org/javaee7/jaspic/dispatching/sam/SamAutoRegistrationListener.java
+++ b/jaspic/dispatching-jsf-cdi/src/main/java/org/javaee7/jaspic/dispatching/sam/SamAutoRegistrationListener.java
@@ -16,7 +16,7 @@ public class SamAutoRegistrationListener extends BaseServletContextListener {
 
     @Override
     public void contextInitialized(ServletContextEvent sce) {
-        JaspicUtils.registerSAM(sce.getServletContext(), new TestServerAuthModule());
+        JaspicUtils.registerSAM(sce.getServletContext(), TestServerAuthModule.class);
     }
 
 }

--- a/jaspic/dispatching/src/main/java/org/javaee7/jaspic/dispatching/sam/SamAutoRegistrationListener.java
+++ b/jaspic/dispatching/src/main/java/org/javaee7/jaspic/dispatching/sam/SamAutoRegistrationListener.java
@@ -16,7 +16,7 @@ public class SamAutoRegistrationListener extends BaseServletContextListener {
 
     @Override
     public void contextInitialized(ServletContextEvent sce) {
-        JaspicUtils.registerSAM(sce.getServletContext(), new TestServerAuthModule());
+        JaspicUtils.registerSAM(sce.getServletContext(), TestServerAuthModule.class);
     }
 
 }

--- a/jaspic/dispatching/src/main/java/org/javaee7/jaspic/dispatching/sam/TestServerAuthModule.java
+++ b/jaspic/dispatching/src/main/java/org/javaee7/jaspic/dispatching/sam/TestServerAuthModule.java
@@ -3,6 +3,7 @@ package org.javaee7.jaspic.dispatching.sam;
 import static javax.security.auth.message.AuthStatus.SEND_CONTINUE;
 import static javax.security.auth.message.AuthStatus.SEND_SUCCESS;
 import static javax.security.auth.message.AuthStatus.SUCCESS;
+import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
 import java.io.IOException;
 import java.security.Principal;
@@ -42,19 +43,27 @@ public class TestServerAuthModule implements ServerAuthModule {
     public AuthStatus validateRequest(MessageInfo messageInfo, Subject clientSubject, Subject serviceSubject) throws AuthException {
         try {
             HttpServletRequest request = (HttpServletRequest) messageInfo.getRequestMessage();
-            HttpServletResponse response = (HttpServletResponse) messageInfo.getResponseMessage();
-
+            HttpServletResponse response = (HttpServletResponse) messageInfo.getResponseMessage();            
+            
             if ("include".equals(request.getParameter("dispatch"))) {
-                request.getRequestDispatcher("/includedServlet")
-                       .include(request, response);
-
-                // "Do nothing", required protocol when returning SUCCESS
-                handler.handle(new Callback[] { new CallerPrincipalCallback(clientSubject, (Principal) null) });
-
-                // When using includes, the response stays open and the main
-                // resource can also write to the response
-                return SUCCESS;
-
+            	
+            	if(messageInfo.getMap().get("javax.security.auth.message.MessagePolicy.isMandatory").equals("true")) {
+                	//Since we do not set a principal, authentication is unsuccessful 
+                	
+                	response.setStatus(SC_UNAUTHORIZED);
+                	return SEND_CONTINUE;
+                } else {
+            	
+	                request.getRequestDispatcher("/includedServlet")
+	                       .include(request, response);
+	
+	                // "Do nothing", required protocol when returning SUCCESS
+	                handler.handle(new Callback[] { new CallerPrincipalCallback(clientSubject, (Principal) null) });
+	
+	                // When using includes, the response stays open and the main
+	                // resource can also write to the response
+	                return SUCCESS;
+                }
             } else {
                 request.getRequestDispatcher("/forwardedServlet")
                        .forward(request, response);

--- a/jaspic/ejb-propagation/src/main/java/org/javaee7/jaspic/ejbpropagation/sam/SamAutoRegistrationListener.java
+++ b/jaspic/ejb-propagation/src/main/java/org/javaee7/jaspic/ejbpropagation/sam/SamAutoRegistrationListener.java
@@ -16,7 +16,7 @@ public class SamAutoRegistrationListener extends BaseServletContextListener {
 
     @Override
     public void contextInitialized(ServletContextEvent sce) {
-        JaspicUtils.registerSAM(sce.getServletContext(), new TestServerAuthModule());
+        JaspicUtils.registerSAM(sce.getServletContext(), TestServerAuthModule.class);
     }
 
 }

--- a/jaspic/ejb-propagation/src/main/java/org/javaee7/jaspic/ejbpropagation/sam/TestServerAuthModule.java
+++ b/jaspic/ejb-propagation/src/main/java/org/javaee7/jaspic/ejbpropagation/sam/TestServerAuthModule.java
@@ -1,6 +1,8 @@
 package org.javaee7.jaspic.ejbpropagation.sam;
 
 import static javax.security.auth.message.AuthStatus.SUCCESS;
+import static javax.security.auth.message.AuthStatus.SEND_CONTINUE;
+import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
 import java.io.IOException;
 import java.security.Principal;
@@ -43,6 +45,7 @@ public class TestServerAuthModule implements ServerAuthModule {
         throws AuthException {
 
         HttpServletRequest request = (HttpServletRequest) messageInfo.getRequestMessage();
+        HttpServletResponse response = (HttpServletResponse) messageInfo.getResponseMessage();
 
         Callback[] callbacks;
 
@@ -50,6 +53,11 @@ public class TestServerAuthModule implements ServerAuthModule {
 
             callbacks = new Callback[] { new CallerPrincipalCallback(clientSubject, "test"),
                 new GroupPrincipalCallback(clientSubject, new String[] { "architect" }) };
+        } else if(messageInfo.getMap().get("javax.security.auth.message.MessagePolicy.isMandatory").equals("true")) {
+        	
+        	// Must set error code if authentication is mandatory, but unsuccessful
+        	response.setStatus(SC_UNAUTHORIZED);
+        	return SEND_CONTINUE;
         } else {
 
             // The JASPIC protocol for "do nothing"

--- a/jaspic/ejb-register-session/src/main/java/org/javaee7/jaspic/registersession/sam/SamAutoRegistrationListener.java
+++ b/jaspic/ejb-register-session/src/main/java/org/javaee7/jaspic/registersession/sam/SamAutoRegistrationListener.java
@@ -16,7 +16,7 @@ public class SamAutoRegistrationListener extends BaseServletContextListener {
 
     @Override
     public void contextInitialized(ServletContextEvent sce) {
-        JaspicUtils.registerSAM(sce.getServletContext(), new TestServerAuthModule());
+        JaspicUtils.registerSAM(sce.getServletContext(), TestServerAuthModule.class);
     }
 
 }

--- a/jaspic/ejb-register-session/src/main/java/org/javaee7/jaspic/registersession/sam/TestServerAuthModule.java
+++ b/jaspic/ejb-register-session/src/main/java/org/javaee7/jaspic/registersession/sam/TestServerAuthModule.java
@@ -1,7 +1,9 @@
 package org.javaee7.jaspic.registersession.sam;
 
 import static java.lang.Boolean.TRUE;
+import static javax.security.auth.message.AuthStatus.SEND_CONTINUE;
 import static javax.security.auth.message.AuthStatus.SUCCESS;
+import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
 import java.io.IOException;
 import java.security.Principal;
@@ -44,6 +46,8 @@ public class TestServerAuthModule implements ServerAuthModule {
         throws AuthException {
 
         HttpServletRequest request = (HttpServletRequest) messageInfo.getRequestMessage();
+        HttpServletResponse response = (HttpServletResponse) messageInfo.getResponseMessage();
+        
         Callback[] callbacks;
 
         Principal userPrincipal = request.getUserPrincipal();
@@ -77,6 +81,11 @@ public class TestServerAuthModule implements ServerAuthModule {
 
             // Tell container to register an authentication session.
             messageInfo.getMap().put("javax.servlet.http.registerSession", TRUE.toString());
+        } else if(messageInfo.getMap().get("javax.security.auth.message.MessagePolicy.isMandatory").equals("true")) {
+        	
+        	// Must set error code if authentication is mandatory, but unsuccessful
+        	response.setStatus(SC_UNAUTHORIZED);
+        	return SEND_CONTINUE;
         } else {
 
             // ### If no registered session and no login request "do nothing"

--- a/jaspic/invoke-ejb-cdi/src/main/java/org/javaee7/jaspic/invoke/sam/SamAutoRegistrationListener.java
+++ b/jaspic/invoke-ejb-cdi/src/main/java/org/javaee7/jaspic/invoke/sam/SamAutoRegistrationListener.java
@@ -16,7 +16,7 @@ public class SamAutoRegistrationListener extends BaseServletContextListener {
 
     @Override
     public void contextInitialized(ServletContextEvent sce) {
-        JaspicUtils.registerSAM(sce.getServletContext(), new TestServerAuthModule());
+        JaspicUtils.registerSAM(sce.getServletContext(), TestServerAuthModule.class);
     }
 
 }

--- a/jaspic/jacc-propagation/src/main/java/org/javaee7/jaspic/jaccpropagation/sam/SamAutoRegistrationListener.java
+++ b/jaspic/jacc-propagation/src/main/java/org/javaee7/jaspic/jaccpropagation/sam/SamAutoRegistrationListener.java
@@ -16,7 +16,7 @@ public class SamAutoRegistrationListener extends BaseServletContextListener {
 
     @Override
     public void contextInitialized(ServletContextEvent sce) {
-        JaspicUtils.registerSAM(sce.getServletContext(), new TestServerAuthModule());
+        JaspicUtils.registerSAM(sce.getServletContext(), TestServerAuthModule.class);
     }
 
 }

--- a/jaspic/jacc-propagation/src/main/java/org/javaee7/jaspic/jaccpropagation/sam/TestServerAuthModule.java
+++ b/jaspic/jacc-propagation/src/main/java/org/javaee7/jaspic/jaccpropagation/sam/TestServerAuthModule.java
@@ -1,6 +1,8 @@
 package org.javaee7.jaspic.jaccpropagation.sam;
 
 import static javax.security.auth.message.AuthStatus.SUCCESS;
+import static javax.security.auth.message.AuthStatus.SEND_CONTINUE;
+import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
 import java.io.IOException;
 import java.security.Principal;
@@ -43,6 +45,7 @@ public class TestServerAuthModule implements ServerAuthModule {
         throws AuthException {
 
         HttpServletRequest request = (HttpServletRequest) messageInfo.getRequestMessage();
+        HttpServletResponse response = (HttpServletResponse) messageInfo.getResponseMessage();
 
         Callback[] callbacks;
 
@@ -50,6 +53,11 @@ public class TestServerAuthModule implements ServerAuthModule {
 
             callbacks = new Callback[] { new CallerPrincipalCallback(clientSubject, "test"),
                 new GroupPrincipalCallback(clientSubject, new String[] { "architect" }) };
+        } else if(messageInfo.getMap().get("javax.security.auth.message.MessagePolicy.isMandatory").equals("true")) {
+        	
+        	// Must set error code if authentication is mandatory, but unsuccessful
+        	response.setStatus(SC_UNAUTHORIZED);
+        	return SEND_CONTINUE;
         } else {
 
             // The JASPIC protocol for "do nothing"

--- a/jaspic/lifecycle/src/main/java/org/javaee7/jaspic/lifecycle/sam/SamAutoRegistrationListener.java
+++ b/jaspic/lifecycle/src/main/java/org/javaee7/jaspic/lifecycle/sam/SamAutoRegistrationListener.java
@@ -16,7 +16,7 @@ public class SamAutoRegistrationListener extends BaseServletContextListener {
 
     @Override
     public void contextInitialized(ServletContextEvent sce) {
-        JaspicUtils.registerSAM(sce.getServletContext(), new TestLifecycleAuthModule());
+        JaspicUtils.registerSAM(sce.getServletContext(), TestLifecycleAuthModule.class);
     }
 
 }

--- a/jaspic/programmatic-authentication/src/main/java/org/javaee7/jaspic/programmaticauthentication/sam/SamAutoRegistrationListener.java
+++ b/jaspic/programmatic-authentication/src/main/java/org/javaee7/jaspic/programmaticauthentication/sam/SamAutoRegistrationListener.java
@@ -16,7 +16,7 @@ public class SamAutoRegistrationListener extends BaseServletContextListener {
 
     @Override
     public void contextInitialized(ServletContextEvent sce) {
-        JaspicUtils.registerSAM(sce.getServletContext(), new TestServerAuthModule());
+        JaspicUtils.registerSAM(sce.getServletContext(), TestServerAuthModule.class);
     }
 
 }

--- a/jaspic/programmatic-authentication/src/main/java/org/javaee7/jaspic/programmaticauthentication/sam/TestServerAuthModule.java
+++ b/jaspic/programmatic-authentication/src/main/java/org/javaee7/jaspic/programmaticauthentication/sam/TestServerAuthModule.java
@@ -2,6 +2,8 @@ package org.javaee7.jaspic.programmaticauthentication.sam;
 
 import static javax.security.auth.message.AuthStatus.SEND_SUCCESS;
 import static javax.security.auth.message.AuthStatus.SUCCESS;
+import static javax.security.auth.message.AuthStatus.SEND_CONTINUE;
+import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
 import java.io.IOException;
 import java.security.Principal;
@@ -44,6 +46,7 @@ public class TestServerAuthModule implements ServerAuthModule {
         throws AuthException {
 
         HttpServletRequest request = (HttpServletRequest) messageInfo.getRequestMessage();
+        HttpServletResponse response = (HttpServletResponse) messageInfo.getResponseMessage();
 
         Callback[] callbacks;
 
@@ -58,6 +61,11 @@ public class TestServerAuthModule implements ServerAuthModule {
                 // the roles of the authenticated user
                 new GroupPrincipalCallback(clientSubject, new String[] { "architect" })
             };
+        } else if(messageInfo.getMap().get("javax.security.auth.message.MessagePolicy.isMandatory").equals("true")) {
+        	
+        	// Must set error code if authentication is mandatory, but unsuccessful
+        	response.setStatus(SC_UNAUTHORIZED);
+        	return SEND_CONTINUE;
         } else {
 
             // The JASPIC protocol for "do nothing"

--- a/jaspic/register-session/src/main/java/org/javaee7/jaspic/registersession/sam/SamAutoRegistrationListener.java
+++ b/jaspic/register-session/src/main/java/org/javaee7/jaspic/registersession/sam/SamAutoRegistrationListener.java
@@ -16,7 +16,7 @@ public class SamAutoRegistrationListener extends BaseServletContextListener {
 
     @Override
     public void contextInitialized(ServletContextEvent sce) {
-        JaspicUtils.registerSAM(sce.getServletContext(), new TestServerAuthModule());
+        JaspicUtils.registerSAM(sce.getServletContext(), TestServerAuthModule.class);
     }
 
 }

--- a/jaspic/register-session/src/main/java/org/javaee7/jaspic/registersession/sam/TestServerAuthModule.java
+++ b/jaspic/register-session/src/main/java/org/javaee7/jaspic/registersession/sam/TestServerAuthModule.java
@@ -2,6 +2,8 @@ package org.javaee7.jaspic.registersession.sam;
 
 import static java.lang.Boolean.TRUE;
 import static javax.security.auth.message.AuthStatus.SUCCESS;
+import static javax.security.auth.message.AuthStatus.SEND_CONTINUE;
+import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
 import java.io.IOException;
 import java.security.Principal;
@@ -44,6 +46,7 @@ public class TestServerAuthModule implements ServerAuthModule {
         throws AuthException {
 
         HttpServletRequest request = (HttpServletRequest) messageInfo.getRequestMessage();
+        HttpServletResponse response = (HttpServletResponse) messageInfo.getResponseMessage();
         Callback[] callbacks;
 
         Principal userPrincipal = request.getUserPrincipal();
@@ -77,6 +80,11 @@ public class TestServerAuthModule implements ServerAuthModule {
 
             // Tell container to register an authentication session.
             messageInfo.getMap().put("javax.servlet.http.registerSession", TRUE.toString());
+        } else if(messageInfo.getMap().get("javax.security.auth.message.MessagePolicy.isMandatory").equals("true")) {
+        	
+        	// Must set error code if authentication is mandatory, but unsuccessful
+        	response.setStatus(SC_UNAUTHORIZED);
+        	return SEND_CONTINUE;
         } else {
 
             // ### If no registered session and no login request "do nothing"

--- a/jaspic/status-codes/src/main/java/org/javaee7/jaspic/statuscodes/sam/SamAutoRegistrationListener.java
+++ b/jaspic/status-codes/src/main/java/org/javaee7/jaspic/statuscodes/sam/SamAutoRegistrationListener.java
@@ -16,7 +16,7 @@ public class SamAutoRegistrationListener extends BaseServletContextListener {
 
     @Override
     public void contextInitialized(ServletContextEvent sce) {
-        JaspicUtils.registerSAM(sce.getServletContext(), new TestServerAuthModule());
+        JaspicUtils.registerSAM(sce.getServletContext(), TestServerAuthModule.class);
     }
 
 }

--- a/jaspic/wrapping/src/main/java/org/javaee7/jaspic/wrapping/sam/SamAutoRegistrationListener.java
+++ b/jaspic/wrapping/src/main/java/org/javaee7/jaspic/wrapping/sam/SamAutoRegistrationListener.java
@@ -20,7 +20,7 @@ public class SamAutoRegistrationListener extends BaseServletContextListener {
 
     @Override
     public void contextInitialized(ServletContextEvent sce) {
-        JaspicUtils.registerSAM(sce.getServletContext(), new TestWrappingServerAuthModule());
+        JaspicUtils.registerSAM(sce.getServletContext(), TestWrappingServerAuthModule.class);
         
         sce.getServletContext()
            .addFilter("Programmatic filter", ProgrammaticFilter.class)


### PR DESCRIPTION
This contains two sets of fixes:
- The SAMs no longer return SUCCESS with emtpy principals for mandatory
authentication
- The ServerAuthContext sets up two SAM module instances to satisfy the
spec requirement that the mandatory flag can be accessed from the
requestPolicy

The first fix is important, as currently the tests fail to return proper
http status codes for unathenticated protected resources on multiple app
servers.

The second fix is just for complying with the letter of the spec, as the
requestPolicy is not actually used in any of the current tests.