### PR TITLE
Unify CDI JarArchive to WebArchive. …

### DIFF
--- a/cdi/bean-discovery-none/src/test/java/org/javaee7/cdi/bean/discovery/none/GreetingTest.java
+++ b/cdi/bean-discovery-none/src/test/java/org/javaee7/cdi/bean/discovery/none/GreetingTest.java
@@ -4,7 +4,9 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -21,9 +23,12 @@ import static org.junit.Assert.assertThat;
 public class GreetingTest {
     @Deployment
     public static Archive<?> deploy() {
-        return ShrinkWrap.create(JavaArchive.class)
+        JavaArchive library = ShrinkWrap.create(JavaArchive.class)
             .addClasses(Greeting.class, FancyGreeting.class)
-            .addAsManifestResource("beans.xml");
+             .addAsManifestResource("beans.xml");
+        return ShrinkWrap.create(WebArchive.class).
+                addAsLibraries(library).
+                addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
     @Inject

--- a/cdi/nobeans-xml/src/test/java/org/javaee7/cdi/nobeans/xml/ScopedBeanTest.java
+++ b/cdi/nobeans-xml/src/test/java/org/javaee7/cdi/nobeans/xml/ScopedBeanTest.java
@@ -5,6 +5,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -21,8 +22,11 @@ import static org.junit.Assert.assertThat;
 public class ScopedBeanTest {
     @Deployment
     public static Archive<?> deploy() {
-        return ShrinkWrap.create(JavaArchive.class)
+        JavaArchive library = ShrinkWrap.create(JavaArchive.class)
             .addClass(ScopedBean.class);
+
+        return ShrinkWrap.create(WebArchive.class).
+                addAsLibraries(library);
     }
 
     @Inject

--- a/jaxrs/singleton/src/test/java/org/javaee7/jaxrs/singleton/AnnotatedSingletonResourceTest.java
+++ b/jaxrs/singleton/src/test/java/org/javaee7/jaxrs/singleton/AnnotatedSingletonResourceTest.java
@@ -5,6 +5,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
 import org.junit.Before;
@@ -49,7 +50,8 @@ public class AnnotatedSingletonResourceTest {
         return ShrinkWrap.create(WebArchive.class)
             .addClasses(
                 MyAnnotatedApplication.class,
-                AnnotatedSingletonResource.class);
+                AnnotatedSingletonResource.class)
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
     @Test

--- a/jta/transactional/src/test/java/org/javaee7/jta/transaction/scope/MyTransactionalBeanTest.java
+++ b/jta/transactional/src/test/java/org/javaee7/jta/transaction/scope/MyTransactionalBeanTest.java
@@ -5,6 +5,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -23,9 +24,10 @@ import static org.junit.Assert.fail;
 public class MyTransactionalBeanTest {
     @Deployment
     public static Archive<?> deploy() {
-        return ShrinkWrap.create(JavaArchive.class)
+        JavaArchive library = ShrinkWrap.create(JavaArchive.class)
             .addClasses(MyTransactionalBean.class, MyTransactionScopedBean.class)
             .addAsManifestResource("beans.xml");
+        return ShrinkWrap.create(WebArchive.class).addAsLibraries(library);
     }
 
     @Inject

--- a/jta/transactional/src/test/java/org/javaee7/jta/transaction/scope/MyTransactionalBeanWithUserTransactionTest.java
+++ b/jta/transactional/src/test/java/org/javaee7/jta/transaction/scope/MyTransactionalBeanWithUserTransactionTest.java
@@ -5,6 +5,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -24,9 +25,11 @@ import static org.junit.Assert.fail;
 public class MyTransactionalBeanWithUserTransactionTest {
     @Deployment
     public static Archive<?> deploy() {
-        return ShrinkWrap.create(JavaArchive.class)
+        JavaArchive library = ShrinkWrap.create(JavaArchive.class)
             .addClasses(MyTransactionalBean.class, MyTransactionScopedBean.class)
             .addAsManifestResource("beans.xml");
+        
+        return ShrinkWrap.create(WebArchive.class).addAsLibraries(library);
     }
 
     @Inject

--- a/jta/transactional/src/test/java/org/javaee7/jta/transactional/MyTransactionalTxTypeBeanTest.java
+++ b/jta/transactional/src/test/java/org/javaee7/jta/transactional/MyTransactionalTxTypeBeanTest.java
@@ -5,6 +5,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -18,8 +19,9 @@ import javax.transaction.TransactionalException;
 public class MyTransactionalTxTypeBeanTest {
     @Deployment
     public static Archive<?> deploy() {
-        return ShrinkWrap.create(JavaArchive.class)
+        Archive library = ShrinkWrap.create(JavaArchive.class)
             .addClass(MyTransactionalTxTypeBean.class);
+        return ShrinkWrap.create(WebArchive.class).addAsLibraries(library);
     }
 
     @Inject

--- a/jta/user-transaction/src/test/java/org/javaee7/jta/user/transaction/UserTransactionTest.java
+++ b/jta/user-transaction/src/test/java/org/javaee7/jta/user/transaction/UserTransactionTest.java
@@ -4,8 +4,8 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -22,8 +22,9 @@ import javax.transaction.*;
 public class UserTransactionTest {
     @Deployment
     public static Archive<?> deploy() {
-        return ShrinkWrap.create(JavaArchive.class)
+        Archive<JavaArchive> library = ShrinkWrap.create(JavaArchive.class)
             .addAsManifestResource("beans.xml");
+        return ShrinkWrap.create(WebArchive.class).addAsLibraries(library);
     }
 
     @Inject


### PR DESCRIPTION
Arquillian does some transformation if using JavaArchive (transform to WAR and adding some beans.xml automatically, etc). In order to make the archive structure more explicit, unify to use WAR file for CDI cases, adding beans.xml in needed cases.

