### PR TITLE
Partial revert of 39f0b461b62d459f42179156047ca1082bdb22a4 . 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,26 +173,22 @@
         <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
             <artifactId>arquillian-junit-container</artifactId>
-            <version>1.1.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.protocol</groupId>
             <artifactId>arquillian-protocol-servlet</artifactId>
-            <version>1.1.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
-            <version>2.1.1</version>
             <scope>test</scope>
             <type>jar</type>
         </dependency>
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-impl-maven-archive</artifactId>
-            <version>2.1.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Setting version for these artifacts aren't needed (already defined in arquillian bom). Additionally, it causes all tests failing when using Wildfly Swarm.

I checked it still works fine for payara-ci-managed.

Can you take a look @arjantijms ? We are using master branch from this repo for our internal tests.

Thanks!