### PR TITLE
Removing default activation of payara-ci-managed profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -335,10 +335,6 @@
         <profile>
             <id>payara-ci-managed</id>
             
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            
             <dependencies>
                 
                 <!-- WebSocket client dependencies -->


### PR DESCRIPTION
Profile payara-ci-managed was activated by default, so during build payara41 was extracted to every target folder.