### PR TITLE
Otherwise they end up in war's lib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,11 +250,13 @@
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
             <version>2.3.2</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
             <version>2.3.2</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Hi all,

I'm reading Arun's book and I find it very good done! Direct to the point without too much bloating discussions.
I was trying to launch the servlets examples in Docker but WildFly had problems to start because some not compatible dependencies (from java 9 with a module_info.java) were being copied in WEB-INF's lib. I set them as 'provided'...

At the time the book was written java 9 wasn't around :-)

Thank in advance for your feedback!
Bye
Fabio