### PR TITLE
Change getSingleResult

### DIFF
--- a/jpa/listeners/src/main/java/org/javaee7/jpa/listeners/MovieBean.java
+++ b/jpa/listeners/src/main/java/org/javaee7/jpa/listeners/MovieBean.java
@@ -65,7 +65,9 @@ public class MovieBean {
     public void updateMovie() {
         Movie m = em.createNamedQuery("Movie.findByName", Movie.class)
             .setParameter("name", "Inception")
-            .getSingleResult();
+            .setMaxResults(1)
+            .getResultList()
+            .get(0);
         m.setName("Inception2");
         em.merge(m);
         em.flush();
@@ -74,7 +76,9 @@ public class MovieBean {
     public void deleteMovie() {
         Movie m = em.createNamedQuery("Movie.findByName", Movie.class)
             .setParameter("name", "Inception2")
-            .getSingleResult();
+            .setMaxResults(1)
+            .getResultList()
+            .get(0);
         em.remove(m);
         em.flush();
     }


### PR DESCRIPTION
[query.getSingleResult()](https://docs.oracle.com/javaee/6/api/javax/persistence/Query.html#getSingleResult()) causes an exception could be thrown if there is not exactly one row returned.

Although this commit does not implement logic on how to decide which result in the result list should be taken, this removes the potential exception/need for a try/catch. Implementation on how to decide which result to take should be made per context.