### PR TITLE
updating jaxb and jaxws to execute jdk17

### DIFF
--- a/jaxws/jaxws-client/pom.xml
+++ b/jaxws/jaxws-client/pom.xml
@@ -18,6 +18,7 @@
                 <!-- wsimport for web service classes generation -->
                 <groupId>com.helger.maven</groupId>
                 <artifactId>jaxws-maven-plugin</artifactId>
+                <version>2.6.2</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>

--- a/jaxws/pom.xml
+++ b/jaxws/pom.xml
@@ -25,15 +25,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.xml.ws</groupId>
-            <artifactId>jaxws-api</artifactId>
-            <version>2.3.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.sun.xml.ws</groupId>
             <artifactId>jaxws-rt</artifactId>
-            <version>2.3.2</version>
+            <version>2.3.5</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -256,12 +256,12 @@
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>2.3.2</version>
+            <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
-            <version>2.3.2</version>
+            <version>3.0.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Updating jaxb and jaxws dependencies to fix some execution issues under jdk17

the previous changes were tested as follows:
command: mvn clean install -Ppayara-remote
windows 11, payara5, Zulu jdk8u312
windows 11, payara5, Zulu jdk11u13
windows 11, payara5, Zulu jdk17u1